### PR TITLE
Fix the destroyer of rabbit nodes

### DIFF
--- a/queue_manipulator.py
+++ b/queue_manipulator.py
@@ -76,7 +76,6 @@ def print_message(_properties, body):
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Various Rabbit queue manipulation tools.')
     parser.add_argument('source_queue_name', help='source queue name', type=str)
-    parser.add_argument('-l', '--limit', help='message limit', type=int, default=100)
     parser.add_argument('-s', '--search', help='message body search', type=str, default=None, nargs='?')
     parser.add_argument('-t', '--timeout', help='Search timeout', type=int, default=30)
     parser.add_argument('message_hash_search', help='message hash search', type=str, default=None, nargs='?')
@@ -104,7 +103,7 @@ def main():
     with RabbitContext(queue_name=args.source_queue_name) as rabbit:
 
         queue_qty = rabbit.get_queue_message_qty()
-        message_limit = min(queue_qty, args.limit)
+        message_limit = min(queue_qty, 100)
 
         if queue_qty == 0:
             print(colored(f'Queue is empty', 'red'))

--- a/queue_manipulator.py
+++ b/queue_manipulator.py
@@ -78,6 +78,7 @@ def parse_arguments():
     parser.add_argument('source_queue_name', help='source queue name', type=str)
     parser.add_argument('-l', '--limit', help='message limit', type=int, default=100)
     parser.add_argument('-s', '--search', help='message body search', type=str, default=None, nargs='?')
+    parser.add_argument('-t', '--timeout', help='Search timeout', type=int, default=30)
     parser.add_argument('message_hash_search', help='message hash search', type=str, default=None, nargs='?')
     parser.add_argument('action', help='action to perform', type=str, default=None, nargs='?',
                         choices=['DELETE', 'MOVE', 'VIEW'])
@@ -109,11 +110,10 @@ def main():
             print(colored(f'Queue is empty', 'red'))
             return
 
-        rabbit.start_listening_for_messages(args.source_queue_name,
-                                            functools.partial(message_callback_function, message_limit=message_limit,
+        rabbit.start_listening_for_messages(functools.partial(message_callback_function, message_limit=message_limit,
                                                               message_body_search=args.search, action=args.action,
                                                               destination_queue_name=args.destination_queue_name,
-                                                              message_hash_search=args.message_hash_search))
+                                                              message_hash_search=args.message_hash_search), timeout=args.timeout)
 
     global FOUND_MESSAGES
 

--- a/utilities/rabbit_context.py
+++ b/utilities/rabbit_context.py
@@ -1,5 +1,3 @@
-import functools
-
 import pika
 
 from config import Config
@@ -66,13 +64,12 @@ class RabbitContext:
     def start_listening_for_messages(self, on_message_callback, timeout=30):
         self._connection.call_later(
             delay=timeout,
-            callback=functools.partial(_timeout_callback, self))
+            callback=self._timeout_callback)
 
         self.channel.basic_consume(
             queue=self.queue_name,
             on_message_callback=on_message_callback)
         self.channel.start_consuming()
 
-
-def _timeout_callback(rabbit_connection):
-    rabbit_connection.close_connection()
+    def _timeout_callback(self):
+        self.channel.stop_consuming()

--- a/utilities/rabbit_context.py
+++ b/utilities/rabbit_context.py
@@ -36,8 +36,8 @@ class RabbitContext:
 
         self._channel = self._connection.channel()
 
-        # We only want to fetch one at a time
-        self._channel.basic_qos(prefetch_count=1)
+        # Limit to 100 messages to avoid rabbit 'issues'
+        self._channel.basic_qos(prefetch_count=100)
 
         self.queue_declare_result = self._channel.queue_declare(queue=self.queue_name, durable=True)
 

--- a/utilities/rabbit_helper.py
+++ b/utilities/rabbit_helper.py
@@ -1,35 +1,4 @@
-import functools
-
 from utilities.rabbit_context import RabbitContext
-
-connection = None
-rabbit = None
-
-
-def init_rabbit(queue):
-    global connection, rabbit
-    rabbit = RabbitContext(queue_name=queue)
-    connection = rabbit.open_connection()
-
-
-def start_listening_for_messages(queue, on_message_callback, timeout=30):
-    global connection, rabbit
-    connection.call_later(
-        delay=timeout,
-        callback=functools.partial(_timeout_callback, rabbit))
-
-    rabbit.channel.basic_consume(
-        queue=queue,
-        on_message_callback=on_message_callback)
-    rabbit.channel.start_consuming()
-
-
-def get_queue_qty():
-    return rabbit.get_queue_message_qty()
-
-
-def _timeout_callback(rabbit_connection):
-    rabbit_connection.close_connection()
 
 
 def add_test_queue(binding_key, exchange_name, queue_name, exchange_type='topic'):


### PR DESCRIPTION
# Context
The rabbit code was doing something dodgy with prefetching messages that ultimately killed the rabbit node it was connecting to (further investigation needed!). 

# What has Changed
* Use the rabbit context object to manage connections and consumers

# How to test
Try searching through a queue with a significant number of messages, the node should now not crash and burn.