### PR TITLE
Removing multiple cloudshell ips

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 google-api-python-client = "*"
 oauth2client = "*"
 flake8 = "*"
+retrying = "*"
 
 [packages]
 pika = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 google-api-python-client = "*"
 oauth2client = "*"
 flake8 = "*"
-retrying = "*"
 
 [packages]
 pika = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f95309bc156013232b0b882e291389212c79f0401ec6d2ca747178c72111e9cc"
+            "sha256": "ef617cf17e416eccf6e8c8557ab4a8b59e211c7c94247f13fb798980482b8dcf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,11 +71,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:3ca40dcf31b86bab3355ee2bb4502aefd37b37798c6d0545cdc62ca99ea5d05a",
-                "sha256:a82b5d60a2ec366a14746f17910dd8348c36a4aeec36da10021307e1951fcc7f"
+                "sha256:13a6a820311662eb91a99810568c2bca5ddc7e44e2163fed4cb3f4d47da132cf",
+                "sha256:2e7e2435978bda1c209b70a9a00b8cbc53c3b00d6f09eb2c991ebba857babf24"
             ],
             "index": "pypi",
-            "version": "==1.19.1"
+            "version": "==1.20.0"
         },
         "google-resumable-media": {
             "hashes": [
@@ -101,40 +101,40 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:1303578092f1f6e4bfbc354c04ac422856c393723d3ffa032fff0f7cb5cfd693",
-                "sha256:229c6b313cd82bec8f979b059d87f03cc1a48939b543fe170b5a9c5cf6a6bc69",
-                "sha256:3cd3d99a8b5568d0d186f9520c16121a0f2a4bcad8e2b9884b76fb88a85a7774",
-                "sha256:41cfb222db358227521f9638a6fbc397f310042a4db5539a19dea01547c621cd",
-                "sha256:43330501660f636fd6547d1e196e395cd1e2c2ae57d62219d6184a668ffebda0",
-                "sha256:45d7a2bd8b4f25a013296683f4140d636cdbb507d94a382ea5029a21e76b1648",
-                "sha256:47dc935658a13b25108823dabd010194ddea9610357c5c1ef1ad7b3f5157ebee",
-                "sha256:480aa7e2b56238badce0b9413a96d5b4c90c3bfbd79eba5a0501e92328d9669e",
-                "sha256:4a0934c8b0f97e1d8c18e76c45afc0d02d33ab03125258179f2ac6c7a13f3626",
-                "sha256:5624dab19e950f99e560400c59d87b685809e4cfcb2c724103f1ab14c06071f7",
-                "sha256:60515b1405bb3dadc55e6ca99429072dad3e736afcf5048db5452df5572231ff",
-                "sha256:610f97ebae742a57d336a69b09a9c7d7de1f62aa54aaa8adc635b38f55ba4382",
-                "sha256:64ea189b2b0859d1f7b411a09185028744d494ef09029630200cc892e366f169",
-                "sha256:686090c6c1e09e4f49585b8508d0a31d58bc3895e4049ea55b197d1381e9f70f",
-                "sha256:7745c365195bb0605e3d47b480a2a4d1baa8a41a5fd0a20de5fa48900e2c886a",
-                "sha256:79491e0d2b77a1c438116bf9e5f9e2e04e78b78524615e2ce453eff62db59a09",
-                "sha256:825177dd4c601c487836b7d6b4ba268db59787157911c623ba59a7c03c8d3adc",
-                "sha256:8a060e1f72fb94eee8a035ed29f1201ce903ad14cbe27bda56b4a22a8abda045",
-                "sha256:90168cc6353e2766e47b650c963f21cfff294654b10b3a14c67e26a4e3683634",
-                "sha256:94b7742734bceeff6d8db5edb31ac844cb68fc7f13617eca859ff1b78bb20ba1",
-                "sha256:962aebf2dd01bbb2cdb64580e61760f1afc470781f9ecd5fe8f3d8dcd8cf4556",
-                "sha256:9c8d9eacdce840b72eee7924c752c31b675f8aec74790e08cff184a4ea8aa9c1",
-                "sha256:af5b929debc336f6bab9b0da6915f9ee5e41444012aed6a79a3c7e80d7662fdf",
-                "sha256:b9cdb87fc77e9a3eabdc42a512368538d648fa0760ad30cf97788076985c790a",
-                "sha256:c5e6380b90b389454669dc67d0a39fb4dc166416e01308fcddd694236b8329ef",
-                "sha256:d60c90fe2bfbee735397bf75a2f2c4e70c5deab51cd40c6e4fa98fae018c8db6",
-                "sha256:d8582c8b1b1063249da1588854251d8a91df1e210a328aeb0ece39da2b2b763b",
-                "sha256:ddbf86ba3aa0ad8fed2867910d2913ee237d55920b55f1d619049b3399f04efc",
-                "sha256:e46bc0664c5c8a0545857aa7a096289f8db148e7f9cca2d0b760113e8994bddc",
-                "sha256:f6437f70ec7fed0ca3a0eef1146591bb754b418bb6c6b21db74f0333d624e135",
-                "sha256:f71693c3396530c6b00773b029ea85e59272557e9bd6077195a6593e4229892a",
-                "sha256:f79f7455f8fbd43e8e9d61914ecf7f48ba1c8e271801996fef8d6a8f3cc9f39f"
+                "sha256:0337debec20fe385bcd49048d6917270efbc17a5119857466559b4db91f8995b",
+                "sha256:164f82a99e08797ea786283b66b45ebe76772d321577d1674ba6fe0200155892",
+                "sha256:172dfba8d9621048c2cbc1d1cf7a02244e9a9a8cff5bb79bb30bcb0c13c7fd31",
+                "sha256:18f4b536d8a9cfa15b3214e0bb628071def94160699e91798f0a954c3b2db88d",
+                "sha256:2283b56bda49b068b0f08d006fffc7dd46eae72322f1a5dec87fc9c218f1dc2d",
+                "sha256:26b33f488a955bf49262d2ce3423d3a8174108506d8f819e8150aca21bdd3b99",
+                "sha256:31cc9b6f70bdd0d9ff53df2d563ea1fb278601d5c625932d8a82d03b08ff3de0",
+                "sha256:37dd8684fbc2bc00766ae6784bcbd7f874bc96527636a341411db811d04ff650",
+                "sha256:424c01189ef51a808669f020368b01204e0f1fa0bf2adab7c8d0d13166f92e9e",
+                "sha256:431c099f20a1f1d97def98f87bb74fa752e8819c2bab23d79089353aed1acc9b",
+                "sha256:4c2f1d0b27bcef301e5d5c1da05ffd7d174f807f61889c006b8e708b16bc978e",
+                "sha256:59b8d738867b59c5daaff5df242b5f3f9c58b47862f603c6ee530964b897b69b",
+                "sha256:8d4f1ee2a67cf8f792d4fc9b8c7bb2148174e838d935f175653aec234752828b",
+                "sha256:97ab9e35b47bda0441332204960f95c1169c55ec8e989381bedd32bdb9f78b05",
+                "sha256:9cf93e185507bfdaa7ed45a90049bd3f1ed3f6357ad3772b31e993ff723cf67d",
+                "sha256:a5a81472c0ca6181492b9291c316ff60c6c94dd3f21c1e8c481f21923d899af0",
+                "sha256:aaa1feb0fdd094af6db0a16cbd446ed94285a50e320aede5971152d9ea022df8",
+                "sha256:b36bf4408f8400ee9ab13ff129e71f2e4c72ce2d8886b744aeab77ce50a55cf6",
+                "sha256:bb345f7e98b38a2c1ef33ff1145687234f78dfeedf308b41b3e41f4b42eba099",
+                "sha256:c13ae15695e0eb4ba2db920d6a197171d2398c675afa4f27460b6381d20a6884",
+                "sha256:c4a233a00cc5b64543e97733902151bc6738396931b3c166aad03a3aaadbd479",
+                "sha256:c521c5f8a95baabba69c68dd0f5e34f37c8adf1a9691f9884dba3eab4ebadc29",
+                "sha256:c772edd094fe3e54d6d54fdecb90c51cb8d07b55e9c1cda2d33e9615e33d07e8",
+                "sha256:cebfba6542855403b29e4bc95bbcd5ab444f21137b440f2fb7c7925ca0e55bfd",
+                "sha256:d7490e013c4bad3e8db804fc6483b47125dc8df0ebcfd6e419bd25df35025301",
+                "sha256:dfb6063619f297cbd22c67530d7465d98348b35d0424bbc1756b36c5ef9f99d4",
+                "sha256:e80a15b48a66f35c7c33db2a7df4034a533b362269d0e60e0036e23f14bac7b5",
+                "sha256:ea444fa1c1ec4f8d2ce965bb01e06148ef9ceb398fb2f627511d50f137eac35b",
+                "sha256:ec986cbf8837a49f9612cc1cfc2a8ccb54875cfce5355a121279de35124ea1db",
+                "sha256:fb641df6de8c4a55c784c24d334d53096954d9b30679d3ce5eb6a4d25c1020a3",
+                "sha256:fb88bd791c8efbcb36de12f0aa519ceec0b7806d3decff16e412e097d4725d44",
+                "sha256:ffa1be3d566a9cbd21a5f2d95fd9262ec6c337c499291bfeb51547b8de18942e"
             ],
-            "version": "==1.23.0"
+            "version": "==1.24.0"
         },
         "idna": {
             "hashes": [
@@ -311,10 +311,10 @@
         },
         "httplib2": {
             "hashes": [
-                "sha256:6901c8c0ffcf721f9ce270ad86da37bc2b4d32b8802d4a9cec38274898a64044",
-                "sha256:cf6f9d5876d796539ec922a2c9b9a7cad9bfd90f04badcdc3bcfa537168052c3"
+                "sha256:34537dcdd5e0f2386d29e0e2c6d4a1703a3b982d34c198a5102e6e5d6194b107",
+                "sha256:409fa5509298f739b34d5a652df762cb0042507dc93f6633e306b11289d6249d"
             ],
-            "version": "==0.13.1"
+            "version": "==0.14.0"
         },
         "mccabe": {
             "hashes": [
@@ -358,6 +358,13 @@
                 "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
             "version": "==2.1.1"
+        },
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "index": "pypi",
+            "version": "==1.3.3"
         },
         "rsa": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ef617cf17e416eccf6e8c8557ab4a8b59e211c7c94247f13fb798980482b8dcf"
+            "sha256": "f95309bc156013232b0b882e291389212c79f0401ec6d2ca747178c72111e9cc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -358,13 +358,6 @@
                 "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
             "version": "==2.1.1"
-        },
-        "retrying": {
-            "hashes": [
-                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
-            ],
-            "index": "pypi",
-            "version": "==1.3.3"
         },
         "rsa": {
             "hashes": [

--- a/cloudshell_utilities/add_cloudshell_ip.py
+++ b/cloudshell_utilities/add_cloudshell_ip.py
@@ -4,7 +4,7 @@ import os
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 
-from cloudshell_utilities.remove_cloudshell_ip import remove_cloudshell_whitelist_entries
+from remove_cloudshell_ip import remove_cloudshell_whitelist_entries
 
 
 def parse_arguments():

--- a/cloudshell_utilities/configure_and_whitelist.sh
+++ b/cloudshell_utilities/configure_and_whitelist.sh
@@ -13,9 +13,6 @@ gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 -
 
 CLOUDSHELL_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
 
-echo "Cleaning whitelist"
-./remove_from_whitelist.sh "$TARGET_PROJECT"
-
 echo "Whitelisting cloudshell IP: $CLOUDSHELL_IP with name ${USER}_cloudshell"
 pipenv run python add_cloudshell_ip.py "$TARGET_PROJECT" "$CLOUDSHELL_IP" || exit 1
 

--- a/cloudshell_utilities/configure_and_whitelist.sh
+++ b/cloudshell_utilities/configure_and_whitelist.sh
@@ -12,6 +12,10 @@ echo "Creating and setting kubectl context for $TARGET_PROJECT"
 gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 --project "$TARGET_PROJECT"
 
 CLOUDSHELL_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
+
+echo "Cleaning whitelist"
+./remove_from_whitelist.sh "$TARGET_PROJECT"
+
 echo "Whitelisting cloudshell IP: $CLOUDSHELL_IP with name ${USER}_cloudshell"
 pipenv run python add_cloudshell_ip.py "$TARGET_PROJECT" "$CLOUDSHELL_IP" || exit 1
 

--- a/cloudshell_utilities/remove_cloudshell_ip.py
+++ b/cloudshell_utilities/remove_cloudshell_ip.py
@@ -22,11 +22,13 @@ def main():
 
     current_authorised_networks = response['masterAuthorizedNetworksConfig']
 
-    for index, network in enumerate(current_authorised_networks['cidrBlocks']):
-        if network['displayName'] == f'{os.getenv("USER")}_cloudshell':
-            current_authorised_networks['cidrBlocks'].pop(index)
+    authorised_networks = []
 
-    new_authorised_networks = {'update': {'desiredMasterAuthorizedNetworksConfig': current_authorised_networks}}
+    for index, network in enumerate(current_authorised_networks['cidrBlocks']):
+        if network['displayName'] != f'{os.getenv("USER")}_cloudshell':
+            authorised_networks.append(network)
+
+    new_authorised_networks = {'update': {'desiredMasterAuthorizedNetworksConfig': authorised_networks}}
 
     update_request = service.projects().locations().clusters().update(name=f'projects/{args.project_id}/locations'
                                                                            f'/europe-west2/clusters/rm-k8s-cluster',

--- a/cloudshell_utilities/remove_cloudshell_ip.py
+++ b/cloudshell_utilities/remove_cloudshell_ip.py
@@ -25,10 +25,6 @@ def main():
     for index, network in enumerate(current_authorised_networks['cidrBlocks']):
         if network['displayName'] == f'{os.getenv("USER")}_cloudshell':
             current_authorised_networks['cidrBlocks'].pop(index)
-            break
-    else:
-        print('Cannot find matching whitelist entry')
-        return
 
     new_authorised_networks = {'update': {'desiredMasterAuthorizedNetworksConfig': current_authorised_networks}}
 

--- a/cloudshell_utilities/remove_cloudshell_ip.py
+++ b/cloudshell_utilities/remove_cloudshell_ip.py
@@ -28,7 +28,14 @@ def main():
         if network['displayName'] != f'{os.getenv("USER")}_cloudshell':
             authorised_networks.append(network)
 
-    new_authorised_networks = {'update': {'desiredMasterAuthorizedNetworksConfig': authorised_networks}}
+    new_authorised_networks = {
+        'update': {
+            'desiredMasterAuthorizedNetworksConfig': {
+                'enabled': True,
+                'cidrBlocks': authorised_networks
+            }
+        }
+    }
 
     update_request = service.projects().locations().clusters().update(name=f'projects/{args.project_id}/locations'
                                                                            f'/europe-west2/clusters/rm-k8s-cluster',


### PR DESCRIPTION
I've updated the `configure_and_whitelist.sh` in cloudshell utilities so it will now remove all duplicate ips that are in the authorised networks.

# Test
- Test by running the `configure_and_whitelist.sh` inside of a GCP environment.