### PR TITLE
log event_channel in find_slow_events_processing

### DIFF
--- a/find_slow_event_processing.py
+++ b/find_slow_event_processing.py
@@ -6,8 +6,9 @@ from config import Config
 
 if __name__ == "__main__":
     sql_query = """
-select event_times.event_type, avg(event_times.timediff), count(*)
+select event_times.event_type, event_times.event_channel, avg(event_times.timediff), count(*)
 from (select event_type,
+             event_channel,
              event_date,
              rm_event_processed,
              ((DATE_PART('day', rm_event_processed::timestamp - event_date::timestamp) * 24 +
@@ -28,7 +29,7 @@ from (select event_type,
                            'RESPONDENT_AUTHENTICATED',
                            'UNDELIVERED_MAIL_REPORTED')
         and rm_event_processed between now() - interval '1 minutes' and now()) as event_times
-      group by event_times.event_type;
+      group by event_times.event_type, event_times.event_channel;
         """
 
     conn = psycopg2.connect(f"dbname='{Config.DB_NAME}' user='{Config.DB_USERNAME}' host='{Config.DB_HOST}' "
@@ -39,4 +40,4 @@ from (select event_type,
     db_result = cur.fetchall()
 
     for one_result in db_result:
-        print(json.dumps({'event_type': one_result[0], 'average_time': one_result[1], 'count': one_result[2]}))
+        print(json.dumps({'event_type': one_result[0], 'event_channel': one_result[1], 'average_time': one_result[2], 'count': one_result[3]}))

--- a/find_slow_event_processing.py
+++ b/find_slow_event_processing.py
@@ -40,4 +40,5 @@ from (select event_type,
     db_result = cur.fetchall()
 
     for one_result in db_result:
-        print(json.dumps({'event_type': one_result[0], 'event_channel': one_result[1], 'average_time': one_result[2], 'count': one_result[3]}))
+        print(json.dumps({'event_type': one_result[0], 'event_channel': one_result[1], 'average_time': one_result[2],
+                          'count': one_result[3]}))


### PR DESCRIPTION
For this ticket: https://trello.com/c/gXd5j9oB/1205-filter-out-daily-event-loads-from-alerts
we're logging the event_channel too now to give us further information and more granularity in filtering out certain events in alerts 