### PR TITLE
Added case-api host and port to deployment yml

### DIFF
--- a/census-rm-toolbox-deployment.yml
+++ b/census-rm-toolbox-deployment.yml
@@ -95,6 +95,10 @@
               configMapKeyRef:
                 name: project-config
                 key: project-name
+          - name: CASEAPI_HOST
+            value: "case-api"
+          - name: CASEAPI_PORT
+            value: "80"
         volumes:
         - name: gcp-credentials-volume
           secret:


### PR DESCRIPTION
The message maker file won't work without case-api host and port being there. It's been added to dev deployment but just needs to be added to the one we use in whitelodge and blacklodge. It'll need to be added to the release file as well if it hasn't already