### PR TITLE
add qid linking functionality

### DIFF
--- a/message_maker.py
+++ b/message_maker.py
@@ -8,6 +8,7 @@ from requests import HTTPError
 from utilities.rabbit_context import RabbitContext
 from config import Config
 
+
 def create_questionnaire_linked_message():
     print('Ok, Im gonna link a questionnaire')
     print('Whats the QID?')
@@ -15,7 +16,6 @@ def create_questionnaire_linked_message():
 
     print('Whats the CaseID?')
     case_id = input()
-
 
     message = {
         "event": {

--- a/message_maker.py
+++ b/message_maker.py
@@ -8,6 +8,45 @@ from requests import HTTPError
 from utilities.rabbit_context import RabbitContext
 from config import Config
 
+def create_questionnaire_linked_message():
+    print('Ok, Im gonna link a questionnaire')
+    print('Whats the QID?')
+    qid = input()
+
+    print('Whats the CaseID?')
+    case_id = input()
+
+
+    message = {
+        "event": {
+            "type": "QUESTIONNAIRE_LINKED",
+            "source": "RM",
+            "channel": "RM",
+            "dateTime": datetime.utcnow().isoformat() + 'Z',
+            "transactionId": str(uuid.uuid4())
+        },
+        "payload": {
+            "uac": {
+                "questionnaireId": qid,
+                "caseId": case_id,
+            }
+        }
+    }
+
+    print(f'Here is the generated message:')
+    print(json.dumps(message, sort_keys=True, indent=4))
+    print(f'Do you want to publish it?')
+    do_publish = input()
+
+    if do_publish != 'yes':
+        print('Not publishing')
+        return
+
+    with RabbitContext() as rabbit:
+        rabbit.publish_message(json.dumps(message), 'application/json', None, exchange='events',
+                               routing_key='event.questionnaire.update')
+        print('Successfully published')
+
 
 def create_refusal_message():
     print('Ok, I am creating a Refusal message for you')
@@ -78,10 +117,13 @@ def create_refusal_message():
 def main():
     print('What type of message do you want?')
     print('1. Refusal')
+    print('2. questionnaire linked')
     message_type = input()
 
     if message_type == '1':
         create_refusal_message()
+    elif message_type == '2':
+        create_questionnaire_linked_message()
     else:
         print('Error: you must choose a valid option')
 

--- a/message_maker.py
+++ b/message_maker.py
@@ -17,6 +17,14 @@ def create_questionnaire_linked_message():
     print('Whats the CaseID?')
     case_id = input()
 
+    response = requests.get(f'http://{Config.CASEAPI_HOST}:{Config.CASEAPI_PORT}/cases/{case_id}')
+
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        print('Error: invalid or non-existent Case ID')
+        return
+
     message = {
         "event": {
             "type": "QUESTIONNAIRE_LINKED",

--- a/message_maker.py
+++ b/message_maker.py
@@ -125,7 +125,7 @@ def create_refusal_message():
 def main():
     print('What type of message do you want?')
     print('1. Refusal')
-    print('2. questionnaire linked')
+    print('2. Questionnaire Linked')
     message_type = input()
 
     if message_type == '1':


### PR DESCRIPTION
## Context
We need to be able to manually link qids to cases via the questionnaire_linked event (mostly from community events that have taken place)

## What has Changed
Add a function to make_messae.py to put a questionnaire_linked event onto rabbit

## How to test
load a small sample
load a small unaddressed batch
pick a qid from the unaddressed batch and pick a case_id
use the toolbox to link them
you should see that uac_qid pair be linked to the caseref of that chosen case

# Links
https://trello.com/c/LYTqf5Ok/1272-community-event-pq-linking-14-10