### PR TITLE
Fix QID check alias

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -16,7 +16,7 @@ alias findbad='curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/badm
 alias viewskipped='curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/skippedmessages | jq'
 alias resetexceptionmanager='curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/reset'
 alias msgwizard='python bad_message_wizard.py'
-alias qidcheck='python qid_checksum_validator.py'
+alias qidcheck='python qid_checksum_validator.py --modulus $QID_MODULUS --factor $QID_FACTOR'
 
 baddetails() {
     curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/badmessage/$1 | jq


### PR DESCRIPTION
# Motivation and Context
When we run `qidcheck` in the toolbox it complains of missing parameters.

# What has changed
Added the missing parameters.

# How to test?
Run it.

# Links
Trello: https://trello.com/c/lIa1ArMU