### PR TITLE
Use consistent fulfilment count file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ fulfilment <FULFILMENT_DATE_FROM> <FULFILMENT_DATE_TO> <DB_USERNAME>
 The fulfilment dates should be in the format of `2019-10-18T16:00:00+01:00`.
 
 After you run this you will prompted to type in your password for the database. Once you entered in your credentials, it will create a CSV file of the counts for you
-in the format of `fulfilment-<date>.csv`.
+in the format of `fulfilments-<date>.csv`.
 
 ### Weekend Fulfilment count
 

--- a/fulfilment_count.py
+++ b/fulfilment_count.py
@@ -30,7 +30,7 @@ def fulfilment_query(fulfilment_date_from, fulfilment_date_to, username, passwor
     cur.execute(sql_query, (fulfilment_date_from, fulfilment_date_to,))
     db_result = cur.fetchall()
 
-    with open(f'fulfilment-{fulfilment_date_to[:10]}.csv', 'w') as out:
+    with open(f'fulfilments-{fulfilment_date_to[:10]}.csv', 'w') as out:
         csv_out = csv.writer(out)
         csv_out.writerow(['treatment_code', 'count'])
         for row in db_result:

--- a/weekend_fulfilment_count.py
+++ b/weekend_fulfilment_count.py
@@ -36,7 +36,7 @@ def execute_query(cur, dates, index, sql_query):
                             f"{str(dates[index + 1].date())}T16:00:00+00:00"))
     db_result = cur.fetchall()
 
-    with open(f'fulfilment-{dates[index + 1].date()}.csv', 'w') as out:
+    with open(f'fulfilments-{dates[index + 1].date()}.csv', 'w') as out:
         csv_out = csv.writer(out)
         csv_out.writerow(['treatment_code', 'count'])
         for row in db_result:


### PR DESCRIPTION
# Motivation and Context
When we switched to using a script in this repo the name of the file changed from `fulfilments-*` to `fufilment-*`, we want to revert to the old name for consistency so the people picking up the file see it where they expect

# What has changed
Use consistent fulfilment count file name

# How to test?
Run the fulfilment count, filename should now match the old runbook

# Links
https://trello.com/c/xlChx2DD/1358-use-consistent-fulfilment-count-file-name