### PR TITLE
Add CCS address listed event to event monitor

### DIFF
--- a/find_slow_event_processing.py
+++ b/find_slow_event_processing.py
@@ -25,7 +25,8 @@ from (select event_type,
                            'NEW_ADDRESS_REPORTED',
                            'SURVEY_LAUNCHED',
                            'RESPONDENT_AUTHENTICATED',
-                           'UNDELIVERED_MAIL_REPORTED')
+                           'UNDELIVERED_MAIL_REPORTED',
+                           'CCS_ADDRESS_LISTED')
         and rm_event_processed between now() - interval '1 minutes' and now()) as event_times
       group by event_times.event_type, event_times.event_channel;
         """


### PR DESCRIPTION
# Motivation and Context
We want to monitor and alert on CCS events.

# What has changed
* Add CCS address listed event to event monitor

# Links
https://trello.com/c/zU2Tu3Pe/368-event-monitor-is-not-picking-up-ccs-events-3
