### PR TITLE
Script to wipe DB and rebuild from ground zero

### DIFF
--- a/groundzero/destroy_schemas.sql
+++ b/groundzero/destroy_schemas.sql
@@ -1,0 +1,28 @@
+begin transaction;
+    IF EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = 'casev2'
+      )
+    THEN
+        drop schema casev2 cascade;
+    END IF;
+
+    IF EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = 'actionv2'
+      )
+    THEN
+        drop schema actionv2 cascade;
+    END IF;
+
+    IF EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = 'uacqid'
+      )
+    THEN
+        drop schema uacqid cascade;
+    END IF;
+commit transaction;

--- a/groundzero/rebuild_from_ground_zero.sh
+++ b/groundzero/rebuild_from_ground_zero.sh
@@ -1,0 +1,32 @@
+cd /app/groundzero/
+psql "sslmode=verify-ca sslrootcert=/root/.postgresql-rw/root.crt sslcert=/root/.postgresql-rw/postgresql.crt sslkey=/root/.postgresql-rw/postgresql.key hostaddr=$DB_HOST_RW user=rmuser pass=password dbname=$DB_NAME_RW" -f destroy_schemas.sql
+
+rm actionv2.sql
+rm casev2.sql
+rm uacqid.sql
+
+curl https://raw.githubusercontent.com/ONSdigital/census-rm-ddl/master/groundzero_ddl/actionv2.sql -o actionv2.sql
+curl https://raw.githubusercontent.com/ONSdigital/census-rm-ddl/master/groundzero_ddl/casev2.sql -o casev2.sql
+curl https://raw.githubusercontent.com/ONSdigital/census-rm-ddl/master/groundzero_ddl/uac_qid.sql -o uacqid.sql
+
+echo "begin transaction;" > header_footer_temp.txt
+cat actionv2.sql >> header_footer_temp.txt
+echo "commit transaction;" >> header_footer_temp.txt
+rm actionv2.sql
+mv header_footer_temp.txt actionv2.sql
+
+echo "begin transaction;" > header_footer_temp.txt
+cat casev2.sql >> header_footer_temp.txt
+echo "commit transaction;" >> header_footer_temp.txt
+rm casev2.sql
+mv header_footer_temp.txt casev2.sql
+
+echo "begin transaction;" > header_footer_temp.txt
+cat uacqid.sql >> header_footer_temp.txt
+echo "commit transaction;" >> header_footer_temp.txt
+rm uacqid.sql
+mv header_footer_temp.txt uacqid.sql
+
+psql "sslmode=verify-ca sslrootcert=/root/.postgresql-rw/root.crt sslcert=/root/.postgresql-rw/postgresql.crt sslkey=/root/.postgresql-rw/postgresql.key hostaddr=$DB_HOST_RW user=rmuser pass=password dbname=$DB_NAME_RW" -f casev2.sql
+psql "sslmode=verify-ca sslrootcert=/root/.postgresql-rw/root.crt sslcert=/root/.postgresql-rw/postgresql.crt sslkey=/root/.postgresql-rw/postgresql.key hostaddr=$DB_HOST_RW user=rmuser pass=password dbname=$DB_NAME_RW" -f actionv2.sql
+psql "sslmode=verify-ca sslrootcert=/root/.postgresql-rw/root.crt sslcert=/root/.postgresql-rw/postgresql.crt sslkey=/root/.postgresql-rw/postgresql.key hostaddr=$DB_HOST_RW user=rmuser pass=password dbname=$DB_NAME_RW" -f uacqid.sql


### PR DESCRIPTION
# Motivation and Context
We don't want to have our performance DB growing and growing every time we run a performance test. To get consistent results we should start from an empty DB every time.

# What has changed
Added script which drops DB schemas, downloads DDL scripts from Github, then recreates DB.

# How to test?
Build yourself a test environment where you don't mind losing all your data. Build & deploy the toolbox (with these changes). Run:
`kubectl exec `kubectl get pods -o name | grep -m1 census-rm-toolbox | cut -d'/' -f 2` -- /bin/bash /app/groundzero/rebuild_from_ground_zero.sh`

Check your DB - you should have no data (i.e. it gets recreated).

# Links
Trello: https://trello.com/c/WiicGgid