### PR TITLE
Add action worker database monitor scripts

### DIFF
--- a/action_worker_database_monitor.py
+++ b/action_worker_database_monitor.py
@@ -3,8 +3,8 @@ import json
 from utilities.db_helper import execute_sql_query
 
 if __name__ == "__main__":
-    sql_query = """SELECT COUNT(*) FROM actionv2.case_to_process;"""
+    sql_query = 'SELECT COUNT(*) FROM actionv2.case_to_process;'
 
     db_result = execute_sql_query(sql_query)
 
-    print(json.dumps({'cases_to_process_count': db_result[0][0]}))
+    print(json.dumps({'case_to_process_count': db_result[0][0]}))

--- a/action_worker_database_monitor.py
+++ b/action_worker_database_monitor.py
@@ -1,0 +1,10 @@
+import json
+
+from utilities.db_helper import execute_sql_query
+
+if __name__ == "__main__":
+    sql_query = """SELECT COUNT(*) FROM actionv2.case_to_process;"""
+
+    db_result = execute_sql_query(sql_query)
+
+    print(json.dumps({'cases_to_process_count': db_result[0][0]}))

--- a/database_monitoring_logger.sh
+++ b/database_monitoring_logger.sh
@@ -1,5 +1,6 @@
 while [ 1 ]
 do
     python find_slow_event_processing.py
+    python action_worker_database_monitor.py
     sleep 59s
 done


### PR DESCRIPTION
# Motivation and Context
We want to be able to monitor action worker activity. This can be combined with the event latency monitor as a single database monitor deployment

# What has changed
* Add action worker database monitor scripts
* Update and rename event latency monitor script to run action worker monitor as well

# How to test?
Run the new script locally and against a cloud DB.

# Links
https://trello.com/c/NDMMGkoW/402-performance-consider-metrics-for-action-worker-8
https://github.com/ONSdigital/census-rm-kubernetes/pull/184
https://github.com/ONSdigital/census-rm-deploy/pull/113