### PR TITLE
Use message_timestamp when calculating message processing time

### DIFF
--- a/find_slow_event_processing.py
+++ b/find_slow_event_processing.py
@@ -9,10 +9,10 @@ from (select event_type,
              event_channel,
              event_date,
              rm_event_processed,
-             ((DATE_PART('day', rm_event_processed::timestamp - event_date::timestamp) * 24 +
-               DATE_PART('hour', rm_event_processed::timestamp - event_date::timestamp)) * 60 +
-              DATE_PART('minute', rm_event_processed::timestamp - event_date::timestamp)) * 60 +
-             DATE_PART('second', rm_event_processed::timestamp - event_date::timestamp) as timediff
+             ((DATE_PART('day', rm_event_processed::timestamp - message_timestamp::timestamp) * 24 +
+               DATE_PART('hour', rm_event_processed::timestamp - message_timestamp::timestamp)) * 60 +
+              DATE_PART('minute', rm_event_processed::timestamp - message_timestamp::timestamp)) * 60 +
+             DATE_PART('second', rm_event_processed::timestamp - message_timestamp::timestamp) as timediff
       from casev2.event
       where event_type in ('RESPONSE_RECEIVED',
                            'REFUSAL_RECEIVED',


### PR DESCRIPTION
# Motivation and Context
A change has been made to record the actual timestamp of messages.  This can be used  when calculating the time for messages to be processed through RM - previously, the timestamp in the message payload was used, which gave misleading stats and was unnecessarily firing off alerts (see the work here: https://trello.com/c/0mdJC6nl)

# What has changed
When calculating the time taken for messages to be processed through RM, the calculation now uses the new message_timestamp field in the casev2.event table, rather than the event_date field.

# How to test?
- Build a Docker image from this branch (`make docker_build`), tag it and push it to Dockerhub
- In the Kubernetes repo, amend `optional/database-monitor-dev-deployment.yml` to point to the Docker image you've tagged and pushed then deploy it (`kubectl apply -f database-monitor-dev-deployment.yml`)
- Run the acceptance tests in your GCP environment to get some messages flowing through
- Check the database-monitor logs.  Check the average processing time for events.  Previously, some of these would have been very high due to the old timestamps in the message payloads.

Note: any dashboards and alerts that already exist will be unaffected by these changes.

# Links
- https://trello.com/c/X1ovZkmK
