### PR TITLE
Restore current project at end of WFH scripts

### DIFF
--- a/cloudshell_utilities/whitelist_for_wfh.sh
+++ b/cloudshell_utilities/whitelist_for_wfh.sh
@@ -28,5 +28,6 @@ pipenv run python whitelist_service_ip.py $WFH_IP case-api-test || exit 1
 pipenv run python whitelist_db_ip.py $WFH_IP "$WFH_NAME" census-rm-blacklodge
 
 gcloud config set project $CURRENT_PROJECT
+gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 --project $CURRENT_PROJECT
 
 popd || exit

--- a/cloudshell_utilities/whitelist_for_wfh.sh
+++ b/cloudshell_utilities/whitelist_for_wfh.sh
@@ -10,6 +10,8 @@ WFH_IP=$1
 WFH_NAME=$2
 pushd "${0%/*}" || exit 1
 
+CURRENT_PROJECT=$(gcloud config get-value project 2> /dev/null)
+
 echo "Whitelisting IP: ${WFH_IP} with name ${WFH_NAME} WFH"
 gcloud config set project census-rm-whitelodge
 gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 --project census-rm-whitelodge
@@ -24,5 +26,7 @@ pipenv run python whitelist_service_ip.py $WFH_IP ops || exit 1
 pipenv run python whitelist_service_ip.py $WFH_IP rabbitmqmanagement || exit 1
 pipenv run python whitelist_service_ip.py $WFH_IP case-api-test || exit 1
 pipenv run python whitelist_db_ip.py $WFH_IP "$WFH_NAME" census-rm-blacklodge
+
+gcloud config set project $CURRENT_PROJECT
 
 popd || exit

--- a/cloudshell_utilities/whitelist_me_for_wfh.sh
+++ b/cloudshell_utilities/whitelist_me_for_wfh.sh
@@ -1,5 +1,7 @@
 pushd "${0%/*}" || exit 1
 
+CURRENT_PROJECT=$(gcloud config get-value project 2> /dev/null)
+
 gcloud auth application-default login
 
 WFH_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
@@ -20,5 +22,7 @@ pipenv run python whitelist_service_ip.py $WFH_IP ops || exit 1
 pipenv run python whitelist_service_ip.py $WFH_IP rabbitmqmanagement || exit 1
 pipenv run python whitelist_service_ip.py $WFH_IP case-api-test || exit 1
 pipenv run python whitelist_db_ip.py $WFH_IP "$USER" census-rm-blacklodge
+
+gcloud config set project $CURRENT_PROJECT
 
 popd || exit

--- a/cloudshell_utilities/whitelist_me_for_wfh.sh
+++ b/cloudshell_utilities/whitelist_me_for_wfh.sh
@@ -1,6 +1,7 @@
 pushd "${0%/*}" || exit 1
 
 CURRENT_PROJECT=$(gcloud config get-value project 2> /dev/null)
+echo Current project is $CURRENT_PROJECT
 
 gcloud auth application-default login
 
@@ -25,5 +26,6 @@ pipenv run python whitelist_db_ip.py $WFH_IP "$USER" census-rm-blacklodge
 
 gcloud config set project $CURRENT_PROJECT
 gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 --project $CURRENT_PROJECT
+echo Restored current project to $(gcloud config get-value project 2> /dev/null)
 
 popd || exit

--- a/cloudshell_utilities/whitelist_me_for_wfh.sh
+++ b/cloudshell_utilities/whitelist_me_for_wfh.sh
@@ -24,5 +24,6 @@ pipenv run python whitelist_service_ip.py $WFH_IP case-api-test || exit 1
 pipenv run python whitelist_db_ip.py $WFH_IP "$USER" census-rm-blacklodge
 
 gcloud config set project $CURRENT_PROJECT
+gcloud container clusters get-credentials rm-k8s-cluster --region europe-west2 --project $CURRENT_PROJECT
 
 popd || exit


### PR DESCRIPTION
# Motivation and Context
Running the WFH script leaves the current project as Black Lodge, which could be dangerous (i.e. mistakes could happen) and it's annoying.

# What has changed
Flip the project back at the end of the script.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/jFApoTnR