### PR TITLE
Include cloudshell_utilities in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .flake8
 .gitignore
 *.yml
-/cloudshell_utilities
 .idea
 .git
 .dockerignore


### PR DESCRIPTION
# Motivation and Context
We're trying to automate the whitelisting process.

# What has changed
Needed to include `cloudshell_utilities` in the toolbox image.

# How to test?
Don't.

# Links
Trello: https://trello.com/c/pcZ7P35t