### PR TITLE
Temporary fix for whitelisting

### DIFF
--- a/cloudshell_utilities/whitelist.py
+++ b/cloudshell_utilities/whitelist.py
@@ -1,9 +1,9 @@
 import argparse
 import json
 
-from cloudshell_utilities.whitelist_cluster_ip import whitelist_cluster_list
-from cloudshell_utilities.whitelist_db_ip import whitelist_db_list
-from cloudshell_utilities.whitelist_service_ip import whitelist_service_ip_list
+from whitelist_db_ip import whitelist_db_list
+from whitelist_service_ip import whitelist_service_ip_list
+from whitelist_cluster_ip import whitelist_cluster_list
 
 
 def parse_arguments():


### PR DESCRIPTION
# Motivation and Context
The whitelisting scripts were broken by fixing the imports in #47, the way it's run relies on them being correct as though `cloudshell_utilities` is the top level directory. This should enable the pipeline whitelisting for now.

# What has changed
* Revert import fixes in whitelist.py

# How to test?
Try the whitelist.sh script locally from within the `cloudshell_utilities` directory, it should not fail with module import errors.

# Links
https://trello.com/c/V3JRDv5E/977-reminders-batch-reminder-print-files-8
