### PR TITLE
Revert import change in whitelist cluster IP script

### DIFF
--- a/cloudshell_utilities/whitelist_cluster_ip.py
+++ b/cloudshell_utilities/whitelist_cluster_ip.py
@@ -3,7 +3,7 @@ import argparse
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 
-from cloudshell_utilities.remove_cloudshell_ip import remove_cloudshell_whitelist_entries
+from remove_cloudshell_ip import remove_cloudshell_whitelist_entries
 
 
 def parse_arguments():


### PR DESCRIPTION
# Motivation and Context
Relies on import being broken because it's treated like the top level directory.

# What has changed
* Revert import change in whitelist cluster IP script

# How to test?

# Links
https://trello.com/c/V3JRDv5E/977-reminders-batch-reminder-print-files-8