### PR TITLE
Changes from classifiers to where_clause

### DIFF
--- a/reminder_batch_scheduler/constants.py
+++ b/reminder_batch_scheduler/constants.py
@@ -11,83 +11,23 @@ ACTION_TYPES_FOR_WAVE = {
 }
 
 WAVE_CLASSIFIERS = {
-    1: {
-        'treatment_code': [
-            'HH_LP1E',
-            'HH_LP1W',
-            'HH_LP2E',
-            'HH_LP2W',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
+    1: "treatment_code IN ('HH_LP1E', 'HH_LP1W', 'HH_LP2E', 'HH_LP2W') AND survey_launched = 'f'",
 
-    2: {
-        'treatment_code': [
-            'HH_LP1E',
-            'HH_LP1W',
-            'HH_LP2E',
-            'HH_LP2W',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
+    2: "treatment_code IN ('HH_LP1E', 'HH_LP1W', 'HH_LP2E', 'HH_LP2W') AND survey_launched = 'f'",
 
-    3: {
-        'treatment_code': [
-            'HH_LP1E',
-            'HH_LP1W',
-        ]
-    },
+    3: "treatment_code IN ('HH_LP1E', 'HH_LP1W')",
 }
 
 ACTION_TYPE_CLASSIFIERS = {
-    'P_RL_1RL1_1': {
-        'treatment_code': [
-            'HH_LP1E',
-            'HH_LP2E',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
-    'P_RL_1RL2B_1': {
-        'treatment_code': [
-            'HH_LP1W',
-            'HH_LP2W',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
-    'P_RL_2RL1': {
-        'treatment_code': [
-            'HH_LP1E',
-            'HH_LP2E',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
-    'P_RL_2RL2B': {
-        'treatment_code': [
-            'HH_LP1W',
-            'HH_LP2W',
-        ],
-        'survey_launched': [
-            'f'
-        ],
-    },
-    'P_QU_H1': {
-        'treatment_code': [
-            'HH_LP1E'
-        ]
-    },
-    'P_QU_H2': {
-        'treatment_code': [
-            'HH_LP1W'
-        ]
-    },
+    'P_RL_1RL1_1': "treatment_code IN ('HH_LP1E', 'HH_LP2E') AND survey_launched = 'f'",
+
+    'P_RL_1RL2B_1': "treatment_code IN ('HH_LP1W', 'HH_LP2W') AND survey_launched = 'f'",
+
+    'P_RL_2RL1': "treatment_code IN ('HH_LP1E', 'HH_LP2E') AND survey_launched = 'f'",
+
+    'P_RL_2RL2B': "treatment_code IN ('HH_LP1W', 'HH_LP2W') AND survey_launched = 'f'",
+
+    'P_QU_H1': "treatment_code IN ('HH_LP1E')",
+
+    'P_QU_H2': "treatment_code IN ('HH_LP1W')"
 }

--- a/reminder_batch_scheduler/reminder_batch.py
+++ b/reminder_batch_scheduler/reminder_batch.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import uuid
 from datetime import datetime
 
@@ -12,7 +11,7 @@ from utilities import db_helper
 
 def main(wave: int, starting_batch: int, max_cases: int, action_plan_id: uuid.UUID, insert_rules: bool = False,
          trigger_date_time: datetime = None):
-    wave_classifiers = constants.WAVE_CLASSIFIERS[wave]
+    wave_classifiers = {'where_clause': constants.WAVE_CLASSIFIERS[wave]}
     selected_batches = select_batches(starting_batch, wave_classifiers, max_cases, action_plan_id)
     action_rule_classifiers = build_action_rule_classifiers(wave, list(selected_batches.keys()))
 
@@ -26,11 +25,11 @@ def main(wave: int, starting_batch: int, max_cases: int, action_plan_id: uuid.UU
     print()
     print(f'Selected print batches: {starting_batch} - {final_batch}')
     print('Current total cases:', total_cases)
-    print('Classifiers JSON for each action type:')
+    print('Classifiers for each action type:')
     for action_type, action_type_classifiers in action_rule_classifiers.items():
         print()
         print(f'Action type: {action_type}')
-        print('Classifiers JSON:')
+        print('Classifiers where clause:')
         print(action_type_classifiers)
 
     if insert_rules:
@@ -63,12 +62,8 @@ def count_batch_cases(batch, wave_classifiers, action_plan_id):
 
 
 def build_batch_count_query(wave_classifiers, action_plan_id):
-    classifier_sql_filters = ['']
     query_param_values = [str(action_plan_id)]
-    for classifier, values in wave_classifiers.items():
-        classifier_sql_filters.append(f" {classifier} IN %s")
-        query_param_values.append(tuple(values))
-    classifiers_query_filters = ' AND'.join(classifier_sql_filters)
+    classifiers_query_filters = f" AND {wave_classifiers['where_clause']}"
 
     return ("SELECT COUNT(*) FROM actionv2.cases "
             "WHERE receipt_received = 'f' "
@@ -83,9 +78,10 @@ def build_batch_count_query(wave_classifiers, action_plan_id):
 def build_action_rule_classifiers(wave, selected_batches):
     action_rule_classifiers = {}
     for action_type in constants.ACTION_TYPES_FOR_WAVE[wave]:
-        classifiers = constants.ACTION_TYPE_CLASSIFIERS[action_type]
-        classifiers['print_batch'] = selected_batches
-        action_rule_classifiers[action_type] = json.dumps(classifiers)
+        select_batch = "','".join(selected_batches)
+        classifiers = f"case_type != 'HI' AND {constants.ACTION_TYPE_CLASSIFIERS[action_type]} " \
+                      f"AND print_batch IN ('{select_batch}')"
+        action_rule_classifiers[action_type] = classifiers
     return action_rule_classifiers
 
 
@@ -119,7 +115,7 @@ def generate_action_rules(action_rule_classifiers, action_plan_id, trigger_date_
     for action_type, classifiers in action_rule_classifiers.items():
         action_rules[action_type] = (
             "INSERT INTO actionv2.action_rule "
-            "(id, action_type, classifiers, trigger_date_time, action_plan_id, has_triggered) "
+            "(id, action_type, user_defined_where_clause, trigger_date_time, action_plan_id, has_triggered) "
             "VALUES (%s, %s, %s, %s, %s, %s);",
             (str(uuid.uuid4()), action_type, classifiers, trigger_date_time, str(action_plan_id), False)
         )

--- a/test/reminder_batch_scheduler/test_reminder_batch.py
+++ b/test/reminder_batch_scheduler/test_reminder_batch.py
@@ -92,7 +92,7 @@ def test_select_batches(patch_execute_sql, starting_batch, expected_number_of_ba
     patch_execute_sql.return_value = ((count_per_batch,),)
 
     # We can use empty classifiers because the DB bit is mocked
-    empty_classifiers = {"where_clause": ""}
+    empty_classifiers = ""
 
     expected_batches = [str(batch) for batch in
                         list(range(starting_batch, starting_batch + expected_number_of_batches))]
@@ -118,7 +118,7 @@ def test_select_batches(patch_execute_sql, starting_batch, expected_number_of_ba
 @pytest.mark.parametrize('wave_classifiers, expected_query, expected_params', [
     # Test cases
     # Simple treatment code classifier
-    ({'where_clause': "treatment_code IN ('HH_DUMMY1', 'HH_DUMMY2')"},
+    ("treatment_code IN ('HH_DUMMY1', 'HH_DUMMY2')",
      ("SELECT COUNT(*) FROM actionv2.cases "
       "WHERE receipt_received = 'f' AND address_invalid = 'f' AND skeleton = 'f' "
       "AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL' "
@@ -129,7 +129,7 @@ def test_select_batches(patch_execute_sql, starting_batch, expected_number_of_ba
      ),
 
     # Classifier with just one value
-    ({'where_clause': "survey_launched IN ('f')"},
+    ("survey_launched IN ('f')",
      ("SELECT COUNT(*) FROM actionv2.cases "
       "WHERE receipt_received = 'f' AND address_invalid = 'f' AND skeleton = 'f' "
       "AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL' "
@@ -139,7 +139,7 @@ def test_select_batches(patch_execute_sql, starting_batch, expected_number_of_ba
      (str(TEST_ACTION_PLAN_ID),)),
 
     # Mix of classifiers
-    ({'where_clause': "treatment_code in ('HH_DUMMY1', 'HH_DUMMY2') AND survey_launched IN ('f')"},
+    ("treatment_code in ('HH_DUMMY1', 'HH_DUMMY2') AND survey_launched IN ('f')",
      ("SELECT COUNT(*) FROM actionv2.cases "
       "WHERE receipt_received = 'f' AND address_invalid = 'f' AND skeleton = 'f' "
       "AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL' "
@@ -192,7 +192,7 @@ def test_generate_action_rules():
     action_rule_id = list(action_rules.values())[0][1][0]
     expected_action_rules = {action_type: (
         "INSERT INTO actionv2.action_rule "
-        "(id, action_type, user_defined_where_clause, trigger_date_time, action_plan_id, has_triggered) "
+        "(id, action_type, classifiers_clause, trigger_date_time, action_plan_id, has_triggered) "
         "VALUES (%s, %s, %s, %s, %s, %s);",
         (action_rule_id, action_type, action_rule_classifiers[action_type], TEST_DATE_TIME, action_plan_id, False)
     )}

--- a/test/reminder_batch_scheduler/test_reminder_batch.py
+++ b/test/reminder_batch_scheduler/test_reminder_batch.py
@@ -169,8 +169,8 @@ def test_build_batch_count_query(wave_classifiers, expected_query, expected_para
                       " AND survey_launched = 'f' AND print_batch IN ('1')"
     }),
     (3, [str(i) for i in range(1, 99)], {
-        'P_QU_H1': f'''case_type != 'HI' AND treatment_code IN ('HH_LP1E') AND print_batch IN ('{TEST_BATCH_COUNT}')''',
-        'P_QU_H2': f'''case_type != 'HI' AND treatment_code IN ('HH_LP1W') AND print_batch IN ('{TEST_BATCH_COUNT}')'''
+        'P_QU_H1': f"case_type != 'HI' AND treatment_code IN ('HH_LP1E') AND print_batch IN ('{TEST_BATCH_COUNT}')",
+        'P_QU_H2': f"case_type != 'HI' AND treatment_code IN ('HH_LP1W') AND print_batch IN ('{TEST_BATCH_COUNT}')"
     }),
 ])
 def test_build_action_rule_classifiers(wave, print_batches, expected_classifiers):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Classifiers have been changed to a where clause. This PR changes the batch reminders script for the new changes.

# What has changed
<!--- What manifest changes have been made? -->
Json classifiers changes to sql where clauses. Script updated to handle this.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Run the batch reminder script by following the readme instructions along with the other branches on this ticket built. 
# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/TnldEmYZ/1023-address-frame-delta-generate-additional-initial-contact-files-13