### PR TITLE
Remove gcloud and kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ COPY .bashrc_extras /tmp
 
 RUN apt-get update && apt-get -yq install curl && apt-get -yq install jq && apt-get -yq install vim-tiny && \
     apt-get -yq install postgresql-client || true && apt-get -yq install openssh-client || true && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get -yq install apt-transport-https ca-certificates gnupg && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt-get update && apt-get -yq install google-cloud-sdk && \
-    apt-get -yq install kubectl && \
     apt-get -yq clean && groupadd --gid 1000 toolbox && \
     useradd --create-home --system --uid 1000 --gid toolbox toolbox && \
     cat /tmp/.bashrc_extras >> /home/toolbox/.bashrc && rm /tmp/.bashrc_extras


### PR DESCRIPTION
# Motivation and Context
The `gcloud` and `kubectl` utilities were present for use by the whitelisting scripts and other scripts which have been moved out of the repo. We should trim away anything which might be used as an attack surface.

# What has changed
Removed the `gcloud` and `kubectl` utilities.

# How to test?
Run the toolbox - does it still work?

# Links
Trello: https://trello.com/c/ZLwtBk8g
