### PR TITLE
Starting Batch Now 0-99

### DIFF
--- a/toolbox/reminder_batch_scheduler/reminder_batch.py
+++ b/toolbox/reminder_batch_scheduler/reminder_batch.py
@@ -147,7 +147,7 @@ def parse_arguments():
                         help='The batch number to start counting at',
                         required=True,
                         type=int,
-                        choices=range(1, 100))
+                        choices=range(0, 100))
     parser.add_argument('-a', '--action-plan-id',
                         help='Action plan UUID',
                         required=True,

--- a/toolbox/tests/reminder_batch_scheduler/test_reminder_batch.py
+++ b/toolbox/tests/reminder_batch_scheduler/test_reminder_batch.py
@@ -9,9 +9,9 @@ from toolbox.tests import unittest_helper
 
 TEST_CASES = [
     # starting_batch, expected_number_of_batches, max_cases, count_per_batch
-    (1, 0, 1, 2),
-    (1, 1, 10, 10),
-    (1, 2, 25, 10),
+    (0, 0, 1, 2),
+    (0, 1, 10, 10),
+    (0, 2, 25, 10),
     (1, 3, 30, 10),
     (10, 10, 100, 10),
     (1, 99, 1000, 10),


### PR DESCRIPTION
# Motivation and Context
The reminder batching script expects to start from 1, it's been confirmed the actual range is 0-99

# What has changed
Starting batch now at 0
Tests updated

# How to test?
Run reminder batch script command and check it wrks if starting batch number is 0

# Links
https://trello.com/c/jOnss47c/1317-start-reminder-batching-at-print-batch-0-instead-of-1
