### PR TITLE
1259 am bulk uninvalidate cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ bulkinvalidaddresses
 ```
 Rows which are successfully processed will be added to `PROCESSED_invalid_addresses_*.csv` and errored rows be appended to `ERROR_invalid_addresses_*.csv` with the corresponding error details written to `ERROR_DETAIL_invalid_addresses_*.csv`.
 
+### Bulk Un-Invalidate Address
+Bulk un-invalidating addresses can be dropped in a bucket for processing, the file format required is
+```csv
+case_id
+16400b37-e0fb-4cf4-9ddf-728abce92049
+```
+Including the header row
+
+The file should be placed in the configured bulk uninvalidated addresses bucket with a name matching `uninvalidated_addresses_*.csv`, then the processor can be run with
+```shell script
+bulkuninvalidateaddresses
+```
+Rows which are successfully processed will be added to `PROCESSED_uninvalidated_addresses_*.csv` and errored rows be appended to `ERROR_uninvalided_addresses_*.csv` with the corresponding error details written to `ERROR_DETAIL_uninvalidated_addresses_*.csv`.
+
 ### Bulk Deactivate UAC
 Bulk deactivate uac files can be dropped in a bucket for processing, the file format required is
 ```csv

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Rows which are successfully processed will be added to `PROCESSED_invalid_addres
 ### Bulk Un-Invalidate Address
 Bulk un-invalidating addresses can be dropped in a bucket for processing, the file format required is
 ```csv
-case_id
+CASE_ID
 16400b37-e0fb-4cf4-9ddf-728abce92049
 ```
 Including the header row

--- a/aliases.sh
+++ b/aliases.sh
@@ -25,6 +25,7 @@ alias bulkinvalidaddresses='python -m toolbox.bulk_processing.invalid_address_pr
 alias bulkdeactivateuacs='python -m toolbox.bulk_processing.deactivate_uac_processor'
 alias bulkaddressupdate='python -m toolbox.bulk_processing.address_update_processor'
 alias invalidaddressdelta='invalid_address_delta.sh'
+alias bulkuninvalidateaddresses='python -m toolbox.bulk_processing.uninvalidate_address_processor'
 
 baddetails() {
     curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/badmessage/$1 | jq

--- a/toolbox/bulk_processing/uninvalidate_address_processor.py
+++ b/toolbox/bulk_processing/uninvalidate_address_processor.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import datetime
+
+from toolbox.bulk_processing.bulk_processor import BulkProcessor
+from toolbox.bulk_processing.processor_interface import Processor
+from toolbox.bulk_processing.validators import case_exists_by_id, is_uuid
+from toolbox.config import Config
+
+
+class UnInvalidateAddressProcessor(Processor):
+    file_prefix = Config.BULK_UNINVALIDATE_ADDRESS_FILE_PREFIX
+    routing_key = Config.UNINVALIDATE_ADDRESS_EVENT_ROUTING_KEY
+    exchange = Config.EVENTS_EXCHANGE
+    bucket_name = Config.BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME
+    project_id = Config.BULK_UNINVALIDATE_ADDRESS_PROJECT_ID
+    schema = {
+        "case_id": [is_uuid(), case_exists_by_id()]
+    }
+
+    def build_event_messages(self, row):
+        address_resolution = "AR"
+        return [{
+            "event": {
+                "type": "RM_UNINVALIDATE_ADDRESS",
+                "source": "RM_UNINVALIDATE_ADDRESS_PROCESSOR",
+                "channel": address_resolution,
+                "dateTime": datetime.utcnow().isoformat() + 'Z',
+                "transactionId": str(uuid.uuid4())
+            },
+            "payload": {
+                "rmUnInvalidateAddress": {
+                    "id": row['case_id']
+                }
+            }
+        }]
+
+
+def main():
+    BulkProcessor(UnInvalidateAddressProcessor()).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/toolbox/bulk_processing/uninvalidate_address_processor.py
+++ b/toolbox/bulk_processing/uninvalidate_address_processor.py
@@ -29,7 +29,7 @@ class UnInvalidateAddressProcessor(Processor):
             },
             "payload": {
                 "rmUnInvalidateAddress": {
-                    "id": row['case_id']
+                    "caseId": row['case_id']
                 }
             }
         }]

--- a/toolbox/bulk_processing/uninvalidate_address_processor.py
+++ b/toolbox/bulk_processing/uninvalidate_address_processor.py
@@ -10,7 +10,7 @@ from toolbox.config import Config
 class UnInvalidateAddressProcessor(Processor):
     file_prefix = Config.BULK_UNINVALIDATE_ADDRESS_FILE_PREFIX
     routing_key = Config.UNINVALIDATE_ADDRESS_EVENT_ROUTING_KEY
-    exchange = Config.EVENTS_EXCHANGE
+    exchange = ''
     bucket_name = Config.BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME
     project_id = Config.BULK_UNINVALIDATE_ADDRESS_PROJECT_ID
     schema = {

--- a/toolbox/bulk_processing/uninvalidate_address_processor.py
+++ b/toolbox/bulk_processing/uninvalidate_address_processor.py
@@ -8,11 +8,11 @@ from toolbox.config import Config
 
 
 class UnInvalidateAddressProcessor(Processor):
-    file_prefix = Config.BULK_UNINVALIDATE_ADDRESS_FILE_PREFIX
-    routing_key = Config.UNINVALIDATE_ADDRESS_EVENT_ROUTING_KEY
+    file_prefix = Config.BULK_UNINVALIDATED_ADDRESS_FILE_PREFIX
+    routing_key = Config.UNINVALIDATED_ADDRESS_EVENT_ROUTING_KEY
     exchange = ''
-    bucket_name = Config.BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME
-    project_id = Config.BULK_UNINVALIDATE_ADDRESS_PROJECT_ID
+    bucket_name = Config.BULK_UNINVALIDATED_ADDRESS_BUCKET_NAME
+    project_id = Config.BULK_UNINVALIDATED_ADDRESS_PROJECT_ID
     schema = {
         "CASE_ID": [is_uuid(), case_exists_by_id()]
     }

--- a/toolbox/bulk_processing/uninvalidate_address_processor.py
+++ b/toolbox/bulk_processing/uninvalidate_address_processor.py
@@ -14,7 +14,7 @@ class UnInvalidateAddressProcessor(Processor):
     bucket_name = Config.BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME
     project_id = Config.BULK_UNINVALIDATE_ADDRESS_PROJECT_ID
     schema = {
-        "case_id": [is_uuid(), case_exists_by_id()]
+        "CASE_ID": [is_uuid(), case_exists_by_id()]
     }
 
     def build_event_messages(self, row):
@@ -29,7 +29,7 @@ class UnInvalidateAddressProcessor(Processor):
             },
             "payload": {
                 "rmUnInvalidateAddress": {
-                    "caseId": row['case_id']
+                    "caseId": row['CASE_ID']
                 }
             }
         }]

--- a/toolbox/config.py
+++ b/toolbox/config.py
@@ -62,6 +62,13 @@ class Config:
     BULK_ADDRESS_UPDATE_PROJECT_ID = os.getenv('BULK_ADDRESS_UPDATE_PROJECT_ID')
     BULK_ADDRESS_UPDATE_ROUTING_KEY = os.getenv('BULK_ADDRESS_UPDATE_ROUTING_KEY', 'case.rm.updated')
 
+    BULK_UNINVALIDATE_ADDRESS_FILE_PREFIX = os.getenv('BULK_UNINVALIDATE_ADDRESS_UPDATE_FILE_PREFIX',
+                                                      'uninvalidated_addresses_')
+    BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME = os.getenv('BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME')
+    BULK_UNINVALIDATE_ADDRESS_PROJECT_ID = os.getenv('BULK_UNINVALIDATE_ADDRESS_PROJECT_ID')
+    UNINVALIDATE_ADDRESS_EVENT_ROUTING_KEY = os.getenv('BULK_UNINVALIDATE_ADDRESS_ROUTING_KEY',
+                                                       'case.rm.unInvalidateAddress')
+
     EVENTS_EXCHANGE = os.getenv('EVENTS_EXCHANGE', 'events')
 
     TREATMENT_CODES = {

--- a/toolbox/config.py
+++ b/toolbox/config.py
@@ -62,12 +62,12 @@ class Config:
     BULK_ADDRESS_UPDATE_PROJECT_ID = os.getenv('BULK_ADDRESS_UPDATE_PROJECT_ID')
     BULK_ADDRESS_UPDATE_ROUTING_KEY = os.getenv('BULK_ADDRESS_UPDATE_ROUTING_KEY', 'case.rm.updated')
 
-    BULK_UNINVALIDATE_ADDRESS_FILE_PREFIX = os.getenv('BULK_UNINVALIDATE_ADDRESS_UPDATE_FILE_PREFIX',
-                                                      'uninvalidated_addresses_')
-    BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME = os.getenv('BULK_UNINVALIDATE_ADDRESS_BUCKET_NAME')
-    BULK_UNINVALIDATE_ADDRESS_PROJECT_ID = os.getenv('BULK_UNINVALIDATE_ADDRESS_PROJECT_ID')
-    UNINVALIDATE_ADDRESS_EVENT_ROUTING_KEY = os.getenv('BULK_UNINVALIDATE_ADDRESS_ROUTING_KEY',
-                                                       'case.rm.unInvalidateAddress')
+    BULK_UNINVALIDATED_ADDRESS_FILE_PREFIX = os.getenv('BULK_UNINVALIDATED_ADDRESS_UPDATE_FILE_PREFIX',
+                                                       'uninvalidated_addresses_')
+    BULK_UNINVALIDATED_ADDRESS_BUCKET_NAME = os.getenv('BULK_UNINVALIDATED_ADDRESS_BUCKET_NAME')
+    BULK_UNINVALIDATED_ADDRESS_PROJECT_ID = os.getenv('BULK_UNINVALIDATED_ADDRESS_PROJECT_ID')
+    UNINVALIDATED_ADDRESS_EVENT_ROUTING_KEY = os.getenv('BULK_UNINVALIDATED_ADDRESS_ROUTING_KEY',
+                                                        'case.rm.unInvalidateAddress')
 
     EVENTS_EXCHANGE = os.getenv('EVENTS_EXCHANGE', 'events')
 

--- a/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
+++ b/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import pytest
+
+from toolbox.bulk_processing.bulk_processor import BulkProcessor
+from toolbox.bulk_processing.uninvalidate_address_processor import UnInvalidateAddressProcessor
+
+
+@pytest.mark.parametrize('case_id',
+                         [('test_case_id', 'TEST'),
+                          ('anything', 'BLAH'), ])
+def test_build_event_messages(case_id):
+    # Given
+    uninvalidate_address_processor = UnInvalidateAddressProcessor()
+
+    # When
+    event_message = uninvalidate_address_processor.build_event_messages({'case_id': case_id})
+
+    # Then
+    assert len(event_message) == 1, 'Should build one and only 1 invalid address event message'
+    assert event_message[0]['event']['type'] == 'RM_UNINVALIDATE_ADDRESS'
+    assert event_message[0]['event']['transactionId'] is not None
+    assert event_message[0]['event']['dateTime'] is not None
+    assert event_message[0]['payload']['rmUnInvalidateAddress']['id'] == case_id
+
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_uninvalidate_address_validation_headers(_patched_storage_client):
+    invalid_address_headers = ["case_id"]
+
+    result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors(invalid_address_headers)
+
+    assert result is None
+
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_uninvalidate_address_validation_headers_fails_case_id(_patched_storage_client):
+    invalid_address_headers = ["not_a_case_id"]
+
+    result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors(invalid_address_headers)
+
+    assert result.line_number == 1
+    assert "not_a_case_id" in result.description
+    assert "case_id" in result.description
+
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_uninvalidate_address_validation_headers_fails_empty(_patched_storage_client):
+    result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors({})
+
+    assert result.line_number == 1
+    assert "case_id" in result.description

--- a/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
+++ b/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
@@ -1,14 +1,10 @@
-from unittest.mock import patch
-
 import pytest
 
 from toolbox.bulk_processing.bulk_processor import BulkProcessor
 from toolbox.bulk_processing.uninvalidate_address_processor import UnInvalidateAddressProcessor
 
 
-@pytest.mark.parametrize('case_id',
-                         [('test_case_id', 'TEST'),
-                          ('anything', 'BLAH'), ])
+@pytest.mark.parametrize('case_id', ['test_case_id', 'TEST', 'anything', 'BLAH'])
 def test_build_event_messages(case_id):
     # Given
     uninvalidate_address_processor = UnInvalidateAddressProcessor()
@@ -24,8 +20,7 @@ def test_build_event_messages(case_id):
     assert event_message[0]['payload']['rmUnInvalidateAddress']['caseId'] == case_id
 
 
-@patch('toolbox.bulk_processing.bulk_processor.storage')
-def test_uninvalidate_address_validation_headers(_patched_storage_client):
+def test_uninvalidate_address_validation_headers(patch_storage):
     invalid_address_headers = ["CASE_ID"]
 
     result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors(invalid_address_headers)
@@ -33,8 +28,7 @@ def test_uninvalidate_address_validation_headers(_patched_storage_client):
     assert result is None
 
 
-@patch('toolbox.bulk_processing.bulk_processor.storage')
-def test_uninvalidate_address_validation_headers_fails_case_id(_patched_storage_client):
+def test_uninvalidate_address_validation_headers_fails_case_id(patch_storage):
     invalid_address_headers = ["not_a_case_id"]
 
     result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors(invalid_address_headers)
@@ -44,8 +38,7 @@ def test_uninvalidate_address_validation_headers_fails_case_id(_patched_storage_
     assert "case_id" in result.description
 
 
-@patch('toolbox.bulk_processing.bulk_processor.storage')
-def test_uninvalidate_address_validation_headers_fails_empty(_patched_storage_client):
+def test_uninvalidate_address_validation_headers_fails_empty(patch_storage):
     result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors({})
 
     assert result.line_number == 1

--- a/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
+++ b/toolbox/tests/bulk_processing/test_uninvalidate_address_processor.py
@@ -14,19 +14,19 @@ def test_build_event_messages(case_id):
     uninvalidate_address_processor = UnInvalidateAddressProcessor()
 
     # When
-    event_message = uninvalidate_address_processor.build_event_messages({'case_id': case_id})
+    event_message = uninvalidate_address_processor.build_event_messages({'CASE_ID': case_id})
 
     # Then
     assert len(event_message) == 1, 'Should build one and only 1 invalid address event message'
     assert event_message[0]['event']['type'] == 'RM_UNINVALIDATE_ADDRESS'
     assert event_message[0]['event']['transactionId'] is not None
     assert event_message[0]['event']['dateTime'] is not None
-    assert event_message[0]['payload']['rmUnInvalidateAddress']['id'] == case_id
+    assert event_message[0]['payload']['rmUnInvalidateAddress']['caseId'] == case_id
 
 
 @patch('toolbox.bulk_processing.bulk_processor.storage')
 def test_uninvalidate_address_validation_headers(_patched_storage_client):
-    invalid_address_headers = ["case_id"]
+    invalid_address_headers = ["CASE_ID"]
 
     result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors(invalid_address_headers)
 
@@ -49,4 +49,4 @@ def test_uninvalidate_address_validation_headers_fails_empty(_patched_storage_cl
     result = BulkProcessor(UnInvalidateAddressProcessor()).find_header_validation_errors({})
 
     assert result.line_number == 1
-    assert "case_id" in result.description
+    assert "CASE_ID" in result.description


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to mark cases as addressInvalid false from a file of case IDs sent from Address Management.

# What has changed
<!--- What manifest changes have been made? -->
New bulk un-invalidate addresses bulk processor added and relevant config.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Get all repos with branches of the same name from the ticket. Build and deploy as necessary and run ATs with regression tests included.
Alternatively mark cases in your GCP env as `addressInvalid` and supply those caseIds to the bulk processor. Check they are now `addressInvalid=false`.
# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/bbi2PO7z/1259-am-uninvalidate-cases-8