### PR TITLE
1484 Fix blank postcode error

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+# Checklist
+Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
+* [ ] Updated census-rm-acceptance-tests version pin (if applicable)
+
 # Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -170,7 +170,7 @@ def ce_e_has_expected_capacity():
 def alphanumeric_postcode():
     def validate(postcode, **_kwargs):
         stripped_postcode = postcode.replace(" ", "")
-        if not stripped_postcode.isalnum():
+        if stripped_postcode and not stripped_postcode.isalnum():
             raise Invalid(f'Postcode "{postcode}" is non alphanumeric')
 
     return validate

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -329,6 +329,16 @@ def test_alphanumeric_postcode_valid():
     # Then no invalid exception is raised
 
 
+def test_alphanumeric_empty_postcode_valid():
+    # Given
+    alphanumeric_postcode_validator = validators.alphanumeric_postcode()
+
+    # When
+    alphanumeric_postcode_validator('')
+
+    # Then no invalid exception is raised
+
+
 def test_alphanumeric_postcode_invalid():
     # Given
     alphanumeric_postcode_validator = validators.alphanumeric_postcode()


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [x] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The bulk address update was giving an error for a blank postcode `Error: Postcode "" is non alphanumeric`. Blank postcodes are allowed in the bulk address update file (only if the actual case has an existing postcode in the DB).

# What has changed
<!--- What manifest changes have been made? -->
* Allow blank postcodes in the file as long as existing case has a postcode in DB
* Updated template reminder to update ATs when bulk processing is updated

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Run with ATs in same branch

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/01zjexNw/1484-am-update-file-bulkaddressupdate-file-erroring-on-non-madatory-fields-being-blank