### PR TITLE
Field-coordinator and FieldOfficerId Mandatory Values

### DIFF
--- a/toolbox/bulk_processing/new_address_processor.py
+++ b/toolbox/bulk_processing/new_address_processor.py
@@ -3,7 +3,7 @@ from toolbox.bulk_processing.processor_interface import Processor
 from toolbox.bulk_processing.validators import mandatory, max_length, numeric, \
     no_padding_whitespace, latitude_longitude, \
     in_set, region_matches_treatment_code, ce_u_has_expected_capacity, ce_e_has_expected_capacity, \
-    alphanumeric_postcode, no_pipe_character, latitude_longitude_range
+    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, alphanumeric_field_values
 from toolbox.config import Config
 
 
@@ -42,8 +42,10 @@ class NewAddressProcessor(Processor):
         'HTC_WILLINGNESS': [mandatory(), in_set({'0', '1', '2', '3', '4', '5'}, label='HTC_WILLINGNESS')],
         'HTC_DIGITAL': [mandatory(), in_set({'0', '1', '2', '3', '4', '5'}, label='HTC_DIGITAL')],
         'TREATMENT_CODE': [mandatory(), in_set(Config.TREATMENT_CODES, label='TREATMENT_CODE')],
-        'FIELDCOORDINATOR_ID': [max_length(10), no_padding_whitespace(), no_pipe_character()],
-        'FIELDOFFICER_ID': [max_length(13), no_padding_whitespace(), no_pipe_character()],
+        'FIELDCOORDINATOR_ID': [mandatory(), max_length(10), no_padding_whitespace(), no_pipe_character(),
+                                alphanumeric_field_values()],
+        'FIELDOFFICER_ID': [mandatory(), max_length(13), no_padding_whitespace(), no_pipe_character(),
+                            alphanumeric_field_values()],
         'CE_EXPECTED_CAPACITY': [numeric(), max_length(4), no_padding_whitespace(),
                                  ce_u_has_expected_capacity(), ce_e_has_expected_capacity()],
         'CE_SECURE': [mandatory(), in_set({'0', '1'}, label='CE_SECURE'),

--- a/toolbox/bulk_processing/new_address_processor.py
+++ b/toolbox/bulk_processing/new_address_processor.py
@@ -3,7 +3,7 @@ from toolbox.bulk_processing.processor_interface import Processor
 from toolbox.bulk_processing.validators import mandatory, max_length, numeric, \
     no_padding_whitespace, latitude_longitude, \
     in_set, region_matches_treatment_code, ce_u_has_expected_capacity, ce_e_has_expected_capacity, \
-    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, alphanumeric_field_values
+    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, alphanumeric_plus_hyphen_field_values
 from toolbox.config import Config
 
 
@@ -43,9 +43,9 @@ class NewAddressProcessor(Processor):
         'HTC_DIGITAL': [mandatory(), in_set({'0', '1', '2', '3', '4', '5'}, label='HTC_DIGITAL')],
         'TREATMENT_CODE': [mandatory(), in_set(Config.TREATMENT_CODES, label='TREATMENT_CODE')],
         'FIELDCOORDINATOR_ID': [mandatory(), max_length(10), no_padding_whitespace(), no_pipe_character(),
-                                alphanumeric_field_values()],
+                                alphanumeric_plus_hyphen_field_values()],
         'FIELDOFFICER_ID': [mandatory(), max_length(13), no_padding_whitespace(), no_pipe_character(),
-                            alphanumeric_field_values()],
+                            alphanumeric_plus_hyphen_field_values()],
         'CE_EXPECTED_CAPACITY': [numeric(), max_length(4), no_padding_whitespace(),
                                  ce_u_has_expected_capacity(), ce_e_has_expected_capacity()],
         'CE_SECURE': [mandatory(), in_set({'0', '1'}, label='CE_SECURE'),

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -176,6 +176,15 @@ def alphanumeric_postcode():
     return validate
 
 
+def alphanumeric_field_values():
+    def validate(value, **_kwargs):
+        stripped_field_value = value.replace("-", "")
+        if not stripped_field_value.isalnum():
+            raise Invalid(f'Field "{value}" is non alphanumeric')
+
+    return validate
+
+
 def latitude_longitude_range():
     def validate(value, **_kwargs):
         try:

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -180,7 +180,7 @@ def alphanumeric_plus_hyphen_field_values():
     def validate(value, **_kwargs):
         stripped_field_value = value.replace("-", "")
         if not stripped_field_value.isalnum():
-            raise Invalid(f'Field "{value}" is non alphanumeric')
+            raise Invalid(f'Value "{value}" contains invalid characters')
 
     return validate
 

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -176,7 +176,7 @@ def alphanumeric_postcode():
     return validate
 
 
-def alphanumeric_field_values():
+def alphanumeric_plus_hyphen_field_values():
     def validate(value, **_kwargs):
         stripped_field_value = value.replace("-", "")
         if not stripped_field_value.isalnum():

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -348,6 +348,25 @@ def test_alphanumeric_postcode_invalid():
         alphanumeric_postcode_validator('TE5 5TE!')
 
 
+def test_alphanumeric_field_values_valid():
+    # Given
+    alphanumeric_field_validator = validators.alphanumeric_field_values()
+
+    # When
+    alphanumeric_field_validator('TE-STT1-ES-01')
+
+    # Then no invalid exception is raised
+
+
+def test_alphanumeric_field_values_invalid():
+    # Given
+    alphanumeric_field_validator = validators.alphanumeric_field_values()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        alphanumeric_field_validator('TE-STT1-ES-!!')
+
+
 def test_latitude_longitude_range_valid():
     # Given
     latitude_longitude_range_validator = validators.latitude_longitude_range()

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -348,23 +348,23 @@ def test_alphanumeric_postcode_invalid():
         alphanumeric_postcode_validator('TE5 5TE!')
 
 
-def test_alphanumeric_field_values_valid():
+def test_alphanumeric_plus_hyphen_field_values_valid():
     # Given
-    alphanumeric_field_validator = validators.alphanumeric_field_values()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
 
     # When
-    alphanumeric_field_validator('TE-STT1-ES-01')
+    alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-01')
 
     # Then no invalid exception is raised
 
 
-def test_alphanumeric_field_values_invalid():
+def test_alphanumeric_plus_hyphen_field_values_invalid():
     # Given
-    alphanumeric_field_validator = validators.alphanumeric_field_values()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
 
     # When, then raises
     with pytest.raises(validators.Invalid):
-        alphanumeric_field_validator('TE-STT1-ES-!!')
+        alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-!!')
 
 
 def test_latitude_longitude_range_valid():


### PR DESCRIPTION
# Motivation and Context
Both have become mandatory with an expected format

# What has changed
Changed to mandatory
Validators
Test

# How to test?
Check all tests pass

# Links
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CRM&title=Address+Frame+specification+2021
https://trello.com/c/oMBjUjR7/1550-field-officer-co-ord-should-be-mandatory-in-sample-validator-5

