### PR TITLE
Handle malformed decimal lat long values

### DIFF
--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -105,7 +105,10 @@ def latitude_longitude(max_precision: int, max_scale: int):
             float(value)
         except ValueError:
             raise Invalid(f'Value "{value}" is not a valid float')
-        integer, decimal = value.split('.')
+        try:
+            integer, decimal = value.split('.')
+        except ValueError:
+            raise Invalid(f'Malformed decimal, Value = "{value}"')
         integer = integer.strip('-')
         scale = len(decimal)
         precision = len(integer) + len(decimal)

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -173,6 +173,15 @@ def test_lat_long_valid():
     # Then no invalid exception is raised
 
 
+def test_lat_long_malformed_decimal():
+    # Given
+    lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        lat_long_validator('1')
+
+
 def test_lat_long_invalid_format():
     # Given
     lat_long_validator = validators.latitude_longitude(max_scale=5, max_precision=10)


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
The script would exception and die if it got a numeric but not well formed decimal value lat/long. It should properly record them as validation failures.

# What has changed
*  Handle malformed decimal lat long values

# How to test?
Check the test, run a sample file with malformed lat longs.

# Links
https://trello.com/c/j3XcUYyF/1564-handle-malformed-decimals-in-sample-validators