### PR TITLE
Fix bulknewaddresses error on region empty

### DIFF
--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -141,10 +141,12 @@ def no_pipe_character():
 
 def region_matches_treatment_code():
     def validate(region, **kwargs):
-        if region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
-            raise Invalid(
-                f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
-
+        try:
+            if region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
+                raise Invalid(
+                    f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
+        except IndexError:
+            pass
     return validate
 
 

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -141,12 +141,9 @@ def no_pipe_character():
 
 def region_matches_treatment_code():
     def validate(region, **kwargs):
-        try:
-            if region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
-                raise Invalid(
-                    f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
-        except IndexError:
-            pass
+        if len(region.strip()) != 0 and region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
+            raise Invalid(
+                f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
     return validate
 
 

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -266,6 +266,14 @@ def test_region_matches_treatment_code_invalid():
         region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': 'HH_TESTE'})
 
 
+def test_region_matches_treatment_code_empty_region_no_error():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When, then doesn't error.
+    region_matches_treatment_code_validator(' ', row={'TREATMENT_CODE': 'HH_TESTE'})
+
+
 def test_ce_u_has_expected_capacity_valid():
     # Given
     ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.

# Motivation and Context
bulknewaddresses throws an IndexError when provided a new address csv with no region.

# What has changed
Add condition to check if region is empty.

# How to test?
Uploaded a new address .csv to my sandboxes census-rm-env-bulk-new-addresses bucket. (This csv needs empty entries for REGION).
Get changes into toolbox pod.
Exec into census-rm-toolbox:
bulknewaddresses
Check census-rm-env-bulk-new-addresses bucket for Error and Error details file to see if Region Missing logged.
# Links
https://trello.com/c/mbaLHPBd
