### PR TITLE
Fix Bulknewaddresses empty treatment Index error

### DIFF
--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -141,7 +141,8 @@ def no_pipe_character():
 
 def region_matches_treatment_code():
     def validate(region, **kwargs):
-        if len(region.strip()) != 0 and region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
+        if region.strip() and kwargs['row']['TREATMENT_CODE'].strip() and \
+                region[0] != kwargs['row']['TREATMENT_CODE'][-1]:
             raise Invalid(
                 f'Region "{region}" does not match region in treatment code "{kwargs["row"]["TREATMENT_CODE"]}"')
     return validate

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -274,6 +274,14 @@ def test_region_matches_treatment_code_empty_region_no_error():
     region_matches_treatment_code_validator(' ', row={'TREATMENT_CODE': 'HH_TESTE'})
 
 
+def test_region_matches_treatment_code_empty_treatment_no_error():
+    # Given
+    region_matches_treatment_code_validator = validators.region_matches_treatment_code()
+
+    # When, then doesn't error.
+    region_matches_treatment_code_validator('N0000', row={'TREATMENT_CODE': ' '})
+
+
 def test_ce_u_has_expected_capacity_valid():
     # Given
     ce_u_has_expected_capacity_validator = validators.ce_u_has_expected_capacity()


### PR DESCRIPTION
# Motivation and Context
When processing new_address file in toolbox (bulknewaddresses) when treatment empty validators.py errors out on IndexError.

# What has changed
Add conditional to check if treatment code exists.
Add test to cover additional change.

# How to test?
Upload a new address .csv to sandboxes census-rm-env-bulk-new-addresses bucket. (This csv needs empty entries for TREATMENT_CODE).
Get changes into toolbox pod.
Exec into census-rm-toolbox:
bulknewaddresses
Check if no IndexError on execution and census-rm-env-bulk-new-addresses bucket for Error and Error details file to see if Treatment Missing logged.

Run tests in PyCharm or with make test

# Links
https://trello.com/c/RogOSjeh
