### PR TITLE
Add new bulk non-compliance processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ bulkaddressupdate
 
 Rows which are successfully processed will be added to `PROCESSED_address_updates_*.csv` and errored rows be appended to `ERROR_address_updates_*.csv` with the corresponding error details written to `ERROR_DETAIL_address_updates_*.csv`.
 
+
+### Bulk Non-Compliance
+Bulk non-compliance files can be dropped in a bucket for processing, the file format required is 
+```csv
+CASE_ID,NC_STATUS,FIELDCOORDINATOR_ID,FIELDOFFICER_ID
+16400b37-e0fb-4cf4-9ddf-728abce92049,NCL,ABC123,XYZ999
+180e2636-d8e5-4949-bced-f7a0c532190c,NCF,ABC123,XYZ999
+```
+Including the header row.
+
+The non-compliance status must be one of 
+```
+NCL - for 1st letter
+NCF - for field follow up
+```
+
+The file should be placed in the configured bulk non-compliance bucket with a name matching `non_compliance_*.csv`, then the processor can be run with
+```shell script
+bulknoncompliance
+```
+Rows which are successfully processed will be added to `PROCESSED_non_compliance_*.csv` and errored rows be appended to `ERROR_non_compliance_*.csv` with the corresponding error details written to `ERROR_DETAIL_non_compliance_*.csv`.
+
+
 ### Find Invalid Address Case IDs from UPRN File
 Run Book - https://collaborate2.ons.gov.uk/confluence/display/SDC/Find+Invalid+Address+Case+ID%27s+by+UPRN+-+ADDRESS_DELTA
 

--- a/aliases.sh
+++ b/aliases.sh
@@ -24,6 +24,7 @@ alias bulkdeactivateuacs='python -m toolbox.bulk_processing.deactivate_uac_proce
 alias bulkaddressupdate='python -m toolbox.bulk_processing.address_update_processor'
 alias invalidaddressdelta='invalid_address_delta.sh'
 alias bulkuninvalidateaddresses='python -m toolbox.bulk_processing.uninvalidate_address_processor'
+alias bulknoncompliance='python -m toolbox.bulk_processing.non_compliance_processor'
 
 baddetails() {
     curl -s http://$EXCEPTIONMANAGER_HOST:$EXCEPTIONMANAGER_PORT/badmessage/$1 | jq

--- a/toolbox/bulk_processing/non_compliance_processor.py
+++ b/toolbox/bulk_processing/non_compliance_processor.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import datetime
+
+from toolbox.bulk_processing.bulk_processor import BulkProcessor
+from toolbox.bulk_processing.processor_interface import Processor
+from toolbox.bulk_processing.validators import alphanumeric_plus_hyphen_field_values, hh_case_exists_by_id, \
+    in_set, is_uuid, max_length, no_padding_whitespace, no_pipe_character
+from toolbox.config import Config
+
+
+class NonComplianceProcessor(Processor):
+    file_prefix = Config.BULK_NON_COMPLIANCE_FILE_PREFIX
+    routing_key = Config.BULK_NON_COMPLIANCE_ROUTING_KEY
+    exchange = ''
+    bucket_name = Config.BULK_NON_COMPLIANCE_BUCKET_NAME
+    project_id = Config.BULK_NON_COMPLIANCE_PROJECT_ID
+    schema = {
+        "CASE_ID": [is_uuid(), hh_case_exists_by_id()],
+        "NC_STATUS": [in_set({"NCL", "NCF"}, label='non-compliance status')],
+        "FIELDCOORDINATOR_ID": [max_length(10), no_padding_whitespace(), no_pipe_character(),
+                                alphanumeric_plus_hyphen_field_values()],
+        "FIELDOFFICER_ID": [max_length(13), no_padding_whitespace(), no_pipe_character(),
+                            alphanumeric_plus_hyphen_field_values()]
+    }
+
+    def build_event_messages(self, row):
+        return [{
+            "event": {
+                "type": "SELECTED_FOR_NON_COMPLIANCE",
+                "source": "NON_COMPLIANCE",
+                "channel": "NC",
+                "dateTime": datetime.utcnow().isoformat() + 'Z',
+                "transactionId": str(uuid.uuid4())
+            },
+            "payload": {
+                "collectionCase": {
+                    "id": row['CASE_ID'],
+                    "fieldCoordinatorId": row['FIELDCOORDINATOR_ID'],
+                    "fieldOfficerId": row['FIELDOFFICER_ID'],
+                    "nonComplianceStatus": row['NC_STATUS'],
+                }
+            }
+        }]
+
+
+def main():
+    BulkProcessor(NonComplianceProcessor()).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -59,6 +59,20 @@ def case_exists_by_id():
     return validate
 
 
+def hh_case_exists_by_id():
+    def validate(case_id, **kwargs):
+        try:
+            case_id_exists = execute_in_connection("SELECT 1 FROM casev2.cases WHERE case_id = %s AND case_type = 'HH'",
+                                                   (case_id,), conn=kwargs['db_connection'])
+        except Exception as e:
+            print(f'Error looking up case ID: {case_id}, Error: {e}')
+            raise Invalid(f'Error looking up case ID: {case_id}')
+        if not case_id_exists:
+            raise Invalid(f'HH Case does not exist in RM for Case ID "{case_id}"')
+
+    return validate
+
+
 def qid_exists():
     def validate(qid, **kwargs):
         try:

--- a/toolbox/config.py
+++ b/toolbox/config.py
@@ -69,6 +69,11 @@ class Config:
     UNINVALIDATED_ADDRESS_EVENT_ROUTING_KEY = os.getenv('BULK_UNINVALIDATED_ADDRESS_ROUTING_KEY',
                                                         'case.rm.unInvalidateAddress')
 
+    BULK_NON_COMPLIANCE_FILE_PREFIX = os.getenv('BULK_NON_COMPLIANCE_FILE_PREFIX', 'non_compliance_')
+    BULK_NON_COMPLIANCE_BUCKET_NAME = os.getenv('BULK_NON_COMPLIANCE_BUCKET_NAME')
+    BULK_NON_COMPLIANCE_PROJECT_ID = os.getenv('BULK_NON_COMPLIANCE_PROJECT_ID')
+    BULK_NON_COMPLIANCE_ROUTING_KEY = os.getenv('BULK_NON_COMPLIANCE_ROUTING_KEY', 'case.rm.nonCompliance')
+
     EVENTS_EXCHANGE = os.getenv('EVENTS_EXCHANGE', 'events')
 
     TREATMENT_CODES = {

--- a/toolbox/tests/bulk_processing/test_non_compliance_processor.py
+++ b/toolbox/tests/bulk_processing/test_non_compliance_processor.py
@@ -54,6 +54,7 @@ def test_non_compliance_validation_headers_fail(_patched_storage_client):
     assert "FIELDCOORDINATORID" in result.description
     assert "FIELDOFFICERID" in result.description
 
+
 @patch('toolbox.bulk_processing.bulk_processor.storage')
 def test_non_compliance_validation_headers_fails_empty(_patched_storage_client):
     result = BulkProcessor(NonComplianceProcessor()).find_header_validation_errors({})

--- a/toolbox/tests/bulk_processing/test_non_compliance_processor.py
+++ b/toolbox/tests/bulk_processing/test_non_compliance_processor.py
@@ -1,0 +1,63 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from toolbox.bulk_processing.bulk_processor import BulkProcessor
+from toolbox.bulk_processing.non_compliance_processor import NonComplianceProcessor
+
+
+@pytest.mark.parametrize('case_id,nc_status,fieldcoordinator_id,fieldofficer_id',
+                         [('test_case_id', 'TEST', 'ABC123', 'XYZ321'),
+                          (uuid.uuid4(), 'NCL', '', ''),
+                          (uuid.uuid4(), 'NCF', '123', '321'),
+                          ('anything', 'BLAH', 'DE', 'BLAH'), ])
+def test_build_event_messages(case_id, nc_status, fieldcoordinator_id, fieldofficer_id):
+    # Given
+    non_compliance_processor = NonComplianceProcessor()
+
+    # When
+    event_messages = non_compliance_processor.build_event_messages(
+        {'CASE_ID': case_id, 'NC_STATUS': nc_status, 'FIELDCOORDINATOR_ID': fieldcoordinator_id,
+         'FIELDOFFICER_ID': fieldofficer_id})
+
+    # Then
+    assert len(event_messages) == 1, 'Should build one and only 1 refusal event message'
+    assert event_messages[0]['event']['type'] == 'SELECTED_FOR_NON_COMPLIANCE'
+    assert event_messages[0]['event']['transactionId'] is not None
+    assert event_messages[0]['event']['dateTime'] is not None
+    assert event_messages[0]['payload']['collectionCase']['id'] == case_id
+    assert event_messages[0]['payload']['collectionCase']['fieldCoordinatorId'] == fieldcoordinator_id
+    assert event_messages[0]['payload']['collectionCase']['fieldOfficerId'] == fieldofficer_id
+    assert event_messages[0]['payload']['collectionCase']['nonComplianceStatus'] == nc_status
+
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_non_compliance_validation_headers(_patched_storage_client):
+    refusal_headers = ["CASE_ID", "NC_STATUS", "FIELDCOORDINATOR_ID", "FIELDOFFICER_ID"]
+
+    result = BulkProcessor(NonComplianceProcessor()).find_header_validation_errors(refusal_headers)
+
+    assert result is None
+
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_non_compliance_validation_headers_fail(_patched_storage_client):
+    refusal_headers = ["ID", "NC_STAT", "FIELDCOORDINATORID", "FIELDOFFICERID"]
+
+    result = BulkProcessor(NonComplianceProcessor()).find_header_validation_errors(refusal_headers)
+
+    assert result.line_number == 1
+    assert "ID" in result.description
+    assert "CASE_ID" in result.description
+    assert "NC_STAT" in result.description
+    assert "FIELDCOORDINATORID" in result.description
+    assert "FIELDOFFICERID" in result.description
+
+@patch('toolbox.bulk_processing.bulk_processor.storage')
+def test_non_compliance_validation_headers_fails_empty(_patched_storage_client):
+    result = BulkProcessor(NonComplianceProcessor()).find_header_validation_errors({})
+
+    assert result.line_number == 1
+    assert "CASE_ID" in result.description
+    assert "NC_STATUS" in result.description

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -91,7 +91,7 @@ def test_hh_case_exists_by_id_succeeds(mock_execute_method):
     # When
     hh_case_exists_validator = validators.hh_case_exists_by_id()
 
-    hh_case_exists_validator("valid_uuid", "HH", db_connection='db_connection')
+    hh_case_exists_validator("valid_uuid", db_connection='db_connection')
 
     # Then no invalid exception is raised
 
@@ -103,7 +103,7 @@ def test_hh_case_exists_by_id_fails(mock_execute_method):
     # When, then raises
     with pytest.raises(validators.Invalid):
         hh_case_exists_validator = validators.hh_case_exists_by_id()
-        hh_case_exists_validator("invalid_uuid", "HH", db_connection='db_connection')
+        hh_case_exists_validator("invalid_uuid", db_connection='db_connection')
 
 
 @pytest.mark.parametrize('value,is_valid', [

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -84,6 +84,28 @@ def test_case_exists_by_id_fails(mock_execute_method):
         case_exists_validator("invalid_uuid", db_connection='db_connection')
 
 
+@patch('toolbox.bulk_processing.validators.execute_in_connection')
+def test_hh_case_exists_by_id_succeeds(mock_execute_method):
+    # Given
+    mock_execute_method.return_value = [(1,)]
+    # When
+    hh_case_exists_validator = validators.hh_case_exists_by_id()
+
+    hh_case_exists_validator("valid_uuid", "HH", db_connection='db_connection')
+
+    # Then no invalid exception is raised
+
+
+@patch('toolbox.bulk_processing.validators.execute_in_connection')
+def test_hh_case_exists_by_id_fails(mock_execute_method):
+    # Given
+    mock_execute_method.return_value = []
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        hh_case_exists_validator = validators.hh_case_exists_by_id()
+        hh_case_exists_validator("invalid_uuid", "HH", db_connection='db_connection')
+
+
 @pytest.mark.parametrize('value,is_valid', [
     (str(uuid.uuid4()), True),
     ('559eea4d-5251-4b4b-b36f-5beaaf48c5f3', True),


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [* ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
Add new bulk non compliance processor

# What has changed
- New bulk non compliance processor
- New validator to error on non HH cases
- Tests

# How to test?
- Run the K8s and terraform branches to create the new bucket and queues
- Follow the instructions in the README to create a file then upload it to your new <env>-bulk-non-compliance bucket
- Run `bulknoncompliance`
- Check that the file has been processed and that there's a message on the case.rm.nonCompliance queue

# Links
- https://trello.com/c/iOTEEkUc
- https://github.com/ONSdigital/census-rm-kubernetes/pull/346
- https://github.com/ONSdigital/census-rm-terraform/pull/238
- https://github.com/ONSdigital/census-rm-docker-dev/pull/73
