### PR TITLE
Attempt fix for weird bulk behaviour

### DIFF
--- a/toolbox/utilities/db_helper.py
+++ b/toolbox/utilities/db_helper.py
@@ -42,7 +42,7 @@ def execute_in_connection_pool(*args, conn_pool):
         conn = conn_pool.getconn()
         cursor = conn.cursor()
         cursor.execute(*args)
-        yield cursor.fetchall()
+        return cursor.fetchall()
     finally:
         conn_pool.putconn(conn)
 
@@ -55,7 +55,7 @@ def execute_in_connection_pool_with_column_names(*args, conn_pool):
         cursor = conn.cursor()
         cursor.execute(*args)
         colnames = [desc[0] for desc in cursor.description]
-        yield [dict(zip(colnames, row)) for row in cursor.fetchall()]
+        return [dict(zip(colnames, row)) for row in cursor.fetchall()]
     finally:
         conn_pool.putconn(conn)
 


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
Bulk processors don't behave themselves when there's data which is failing validation.

# What has changed
Python trickery.

# How to test?
Run the new AT attached to the Trello ticket

# Links
Trello: https://trello.com/c/Bl6cm3ja