### PR TITLE
Address update script use database

### DIFF
--- a/toolbox/bulk_processing/build_address_update_from_sample.py
+++ b/toolbox/bulk_processing/build_address_update_from_sample.py
@@ -3,11 +3,9 @@ import csv
 from copy import copy
 from pathlib import Path
 
-import requests
-from requests import HTTPError
-
 from toolbox.bulk_processing.address_update_processor import AddressUpdateProcessor
 from toolbox.config import Config
+from toolbox.utilities import db_helper
 
 
 def generate_address_update_file(file_to_process: Path):
@@ -32,13 +30,14 @@ def generate_address_update_file(file_to_process: Path):
                              f'missing field names: {expected_input_fields.difference(actual_fieldnames)}, '
                              f'unexpected fieldnames: {actual_fieldnames.difference(expected_input_fields)}')
 
-        with open(output_address_update_file, 'w') as open_output_file:
+        with open(output_address_update_file,
+                  'w') as open_output_file, db_helper.connect_to_read_replica_pool() as conn_pool:
             output_writer = csv.DictWriter(open_output_file, fieldnames=address_update_fieldnames)
             output_writer.writeheader()
 
             for line_number, row in enumerate(file_reader, 1):
                 try:
-                    case_id = get_case_id_from_case_api(row['UPRN'], line_number)
+                    case_id = get_case_id_from_uprn(row['UPRN'], line_number, conn_pool=conn_pool)
                 except Exception:
                     output_address_update_file.unlink()
                     raise
@@ -53,18 +52,12 @@ def generate_address_update_file(file_to_process: Path):
     return output_address_update_file
 
 
-def get_case_id_from_case_api(uprn, line_number):
-    response = requests.get(f'http://{Config.CASEAPI_HOST}:{Config.CASEAPI_PORT}/cases/uprn/{uprn}')
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        if response.status_code == 404:
-            raise ValueError(f'Error 404: Cannot find the UPRN {uprn} on line {line_number}')
-        print(f'Network or Internal Server Error on line {line_number}')
-        raise
-
-    result = response.json()
-    case_ids = [case['id'] for case in result]
+def get_case_id_from_uprn(uprn, line_number, conn_pool):
+    result = db_helper.execute_in_connection_pool('SELECT case_id FROM casev2.cases WHERE uprn = %s', (uprn,),
+                                                  conn_pool=conn_pool)
+    case_ids = [row[0] for row in result]
+    if len(case_ids) < 1:
+        raise ValueError(f'UPRN {uprn} does not match any cases, line {line_number}')
     if len(case_ids) > 1:
         raise ValueError(f'UPRN {uprn} matches multiple case IDs, line {line_number}')
     return case_ids[0]


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We're making a change to the generate address update script to get case ids from the DB instead of the case-api. When testing with the case-api version, it was gonna take up to an hour to generate the file while using the updated version takes about ~10 mins.

# What has changed
<!--- What manifest changes have been made? -->
- Updated the `build_address_update_from_sample.py` script to call the DB instead of the case-api
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
- Run `make test`
- Should still work

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
[Trello](https://trello.com/c/VbVjIyeC)