### PR TITLE
Output list of LSOA errors and include LSOA count output

### DIFF
--- a/toolbox/reminder_scheduler/reminder_lsoa.py
+++ b/toolbox/reminder_scheduler/reminder_lsoa.py
@@ -20,8 +20,7 @@ def main(lsoa_file_path: Path, reminder_action_type: str, action_plan_id: uuid.U
 
     print()
     print(f'Reminder Action type: {reminder_action_type}')
-    print('Classifiers clause:')
-    print(action_rule_classifiers)
+    print(f'Count of LSOAs to use in classifiers clause: {len(lsoas)}')
 
     if insert_rule:
         action_rule = generate_action_rule(reminder_action_type, action_rule_classifiers, action_plan_id,

--- a/toolbox/tests/reminder_scheduler/test_reminder_helper.py
+++ b/toolbox/tests/reminder_scheduler/test_reminder_helper.py
@@ -30,17 +30,23 @@ def test_check_lsoas_exit():
         check_lsoas(lsoas)
 
 
-def test_check_lsoas_():
-    unittest_helper.assertTrue(check_lsoa(1, "E00000001"))
-
-
 def test_check_lsoa_is_valid():
-    unittest_helper.assertTrue(check_lsoa(1, "E00000001"))
+    unittest_helper.assertEqual([], check_lsoa(1, "E00000001"))
 
 
 def test_check_lsoa_invalid_format():
-    unittest_helper.assertFalse(check_lsoa(1, "'E100000001'"))
+    expected_error = ['Row: 1, LSOA "E1000000\'" is not alphanumeric']
+    unittest_helper.assertEqual(expected_error, check_lsoa(1, "E1000000'"))
 
 
 def test_check_lsoa_invalid_length():
-    unittest_helper.assertFalse(check_lsoa(1, "E000000001"))
+    expected_error = ["Row: 1, LSOA 'E000000001' is too long"]
+    unittest_helper.assertEqual(expected_error, check_lsoa(1, "E000000001"))
+
+
+def test_check_lsoa_invalid_format_and_length():
+    expected_error = [
+        'Row: 1, LSOA "\'E000000001\'" is not alphanumeric',
+        'Row: 1, LSOA "\'E000000001\'" is too long'
+    ]
+    unittest_helper.assertEqual(expected_error, check_lsoa(1, "'E000000001'"))

--- a/toolbox/utilities/reminder_helper.py
+++ b/toolbox/utilities/reminder_helper.py
@@ -8,16 +8,20 @@ def get_lsoas_from_file(lsoa_file_path):
 
 
 def check_lsoas(lsoas):
-    if not all(check_lsoa(row, lsoa) for row, lsoa in enumerate(lsoas, 1)):
+    errors = []
+    for row, lsoa in enumerate(lsoas, 1):
+        errors.extend(check_lsoa(row, lsoa))
+    if errors:
         print('INVALID FILE, EXITING')
+        for error in errors:
+            print(error)
         exit(1)
 
 
 def check_lsoa(row, lsoa):
+    row_errors = []
     if not lsoa.isalnum():
-        print(f'Row: {row}, LSOA {repr(lsoa)} is not alphanumeric')
-        return False
+        row_errors.append(f'Row: {row}, LSOA {repr(lsoa)} is not alphanumeric')
     if len(lsoa) > 9:
-        print(f'Row: {row}, LSOA {repr(lsoa)} is too long')
-        return False
-    return True
+        row_errors.append(f'Row: {row}, LSOA {repr(lsoa)} is too long')
+    return row_errors


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If there were any errors when the reminder LSOA scripts were run, the script would only output the first error encountered and exit. Instead, it would be more useful to output all of the errors, then exit.

We should also just output the LSOA count instead of a string with potentially thousands of LSOAs (thanks for the heads up @AdamHawtin)

# What has changed
<!--- What manifest changes have been made? -->
Updated functions and tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Either tweak the unit tests to see output, or run one of the `reminderlsoa...` scripts from the README with an invalid file.

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/eMtwbrQk/1703-two-runbooks-for-response-driven-reminders-5