### PR TITLE
Optionally suppress SQL write output

### DIFF
--- a/toolbox/reminder_scheduler/reminder_lsoa.py
+++ b/toolbox/reminder_scheduler/reminder_lsoa.py
@@ -26,11 +26,10 @@ def main(lsoa_file_path: Path, reminder_action_type: str, action_plan_id: uuid.U
         action_rule = generate_action_rule(reminder_action_type, action_rule_classifiers, action_plan_id,
                                            trigger_date_time)
         print()
-        print('Generated action rule:')
-        print(action_rule)
-        print('')
         print('About to insert action rule for:')
         print('Action type:', colored(reminder_action_type, "red"))
+        print('Action Plan ID:', colored(action_plan_id, "red"))
+        print('Number of LSOAs from file:', colored(str(len(lsoas)), "red"))
         print('Trigger date time:', colored(trigger_date_time.isoformat(), 'red'))
         if not confirm_insert_rule():
             print(colored('ABORTING', 'red'))
@@ -67,8 +66,8 @@ def generate_action_rule(action_type, action_rule_classifiers, action_plan_id, t
 
 def insert_action_rule(action_rule):
     with db_helper.open_write_cursor(Config.DB_HOST_ACTION, Config.DB_ACTION_CERTIFICATES) as db_cursor:
-        print("Inserting action rule", action_rule)
-        db_helper.execute_sql_query_with_write(db_cursor, action_rule[0], action_rule[1])
+        print("Inserting action rule")
+        db_helper.execute_sql_query_with_write(db_cursor, action_rule[0], action_rule[1], suppress_sql_print=True)
 
 
 def parse_trigger_date_time(trigger_date_time):

--- a/toolbox/tests/reminder_scheduler/test_reminder_lsoa.py
+++ b/toolbox/tests/reminder_scheduler/test_reminder_lsoa.py
@@ -1,6 +1,6 @@
 import uuid
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, ANY
 
 import pytest
 import rfc3339
@@ -38,7 +38,7 @@ def test_main_with_db_insert_rule(_mock_csv_data, patch_input, patch_db_helper):
 
     # Then
     patch_input.assert_called_once()
-    patch_db_helper.execute_sql_query_with_write.assert_called_once()
+    patch_db_helper.execute_sql_query_with_write.assert_called_once_with(ANY, ANY, ANY, suppress_sql_print=True)
 
 
 @patch('toolbox.reminder_scheduler.reminder_lsoa.db_helper')

--- a/toolbox/utilities/db_helper.py
+++ b/toolbox/utilities/db_helper.py
@@ -70,9 +70,10 @@ def execute_parametrized_sql_query(sql_query, values: tuple, db_host=Config.DB_H
     return result
 
 
-def execute_sql_query_with_write(cursor, sql_query, values: tuple):
+def execute_sql_query_with_write(cursor, sql_query, values: tuple, suppress_sql_print=False):
     sanity_checked_sql = cursor.mogrify(sql_query, values)
-    print(colored(f'RUNNING SQL WITH WRITE: {sanity_checked_sql}', 'red'))
+    if not suppress_sql_print:
+        print(colored(f'RUNNING SQL WITH WRITE: {sanity_checked_sql}', 'red'))
     cursor.execute(sanity_checked_sql)
 
 


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When processing response-driven reminders by LSOA, we want to ensure we don't dump out lots of unneeded text to the screen.

# What has changed
<!--- What manifest changes have been made? -->
* Added an optional param to suppress SQL output printing 
* Reduced logging noise in LSOA script

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
Run the LSOA reminder script from the README and make sure it still works, but doesn't print the action rule SQL to screen.

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
https://trello.com/c/3IJMhKSm/1820-update-response-driven-reminders-to-remove-unneeded-logging
https://trello.com/c/eMtwbrQk/1703-two-runbooks-for-response-driven-reminders-5