### PR TITLE
Fix Exception Message Column When All Page Exception None

### DIFF
--- a/toolbox/message_tools/bad_message_wizard.py
+++ b/toolbox/message_tools/bad_message_wizard.py
@@ -404,7 +404,6 @@ def pretty_print_bad_message_summaries(bad_message_summaries, start_index):
     print('')
     header = get_msg_headers(column_widths)
     print(header)
-
     print(f'     ---|{"-" * (column_widths["messageHash"] + 2)}'
           f'{"-" * (column_widths["exceptionMessage"] + 2)}-'
           f'|{"-" * (column_widths["firstSeen"] + 2)}'
@@ -457,6 +456,10 @@ def get_msg_column_widths(bad_message_summaries):
         'firstSeen': max(len(str(summary['firstSeen'])) for summary in bad_message_summaries),
         'queues': max_queue_length,
     }
+
+    exception_header_min_length = len('Exception Message')
+    if column_widths['exceptionMessage'] < exception_header_min_length:
+        column_widths['exceptionMessage'] = exception_header_min_length
     return column_widths
 
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Simple cosmetic fix, for formatting issue when message wizard is displaying a page with exception message all as None, the column would be 4 chars wide as it is set off the length of the exception message: 'None'.  I fixed it for my local and wanted it in master.

# What has changed
<!--- What manifest changes have been made? -->
If the largest exception message for a page is shorter than the words 'Exception Message' the table column is set to the width of 'Exception Message' to prevent issues with formatting.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually tested? -->
With an empty rabbit in own gcp project, create a message that has a None exception message in toolbox. See if column is correct width.

# Links
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
