### PR TITLE
add adhoc reminders to LSOA reminder script

### DIFF
--- a/toolbox/reminder_scheduler/constants.py
+++ b/toolbox/reminder_scheduler/constants.py
@@ -31,4 +31,6 @@ ACTION_TYPES_FOR_RESPONSE_DRIVEN_REMINDER = [
     'P_RD_RNP42B',
     'P_RD_RNP51',
     'P_RD_RNP52B',
+    'P_QU_H1',
+    'P_QU_H2'
 ]


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
To Allow New Adhoc response driven reminders

# What has changed
Added the new pack codes:   'P_QU_H1', 'P_QU_H2' to 'choices' for lsoa reminders

# How to test?
pipenv install --dev
make test


