### PR TITLE
Bug fix for empty strings

### DIFF
--- a/toolbox/bulk_processing/new_address_processor.py
+++ b/toolbox/bulk_processing/new_address_processor.py
@@ -8,7 +8,7 @@ from toolbox.bulk_processing.validators import mandatory, max_length, numeric, \
     no_padding_whitespace, latitude_longitude, \
     in_set, region_matches_treatment_code, ce_u_has_expected_capacity, ce_e_has_expected_capacity, \
     alphanumeric_postcode, no_pipe_character, latitude_longitude_range, \
-    alphanumeric_plus_hyphen_field_values_ignore_empty_strings
+    alphanumeric_plus_hyphen_field_values
 from toolbox.config import Config
 from toolbox.logger import logger_initial_config
 
@@ -49,9 +49,9 @@ class NewAddressProcessor(Processor):
         'HTC_DIGITAL': [mandatory(), in_set({'0', '1', '2', '3', '4', '5'}, label='HTC_DIGITAL')],
         'TREATMENT_CODE': [mandatory(), in_set(Config.TREATMENT_CODES, label='TREATMENT_CODE')],
         'FIELDCOORDINATOR_ID': [mandatory(), max_length(10), no_padding_whitespace(), no_pipe_character(),
-                                alphanumeric_plus_hyphen_field_values_ignore_empty_strings()],
+                                alphanumeric_plus_hyphen_field_values()],
         'FIELDOFFICER_ID': [mandatory(), max_length(13), no_padding_whitespace(), no_pipe_character(),
-                            alphanumeric_plus_hyphen_field_values_ignore_empty_strings()],
+                            alphanumeric_plus_hyphen_field_values()],
         'CE_EXPECTED_CAPACITY': [numeric(), max_length(4), no_padding_whitespace(),
                                  ce_u_has_expected_capacity(), ce_e_has_expected_capacity()],
         'CE_SECURE': [mandatory(), in_set({'0', '1'}, label='CE_SECURE'),

--- a/toolbox/bulk_processing/new_address_processor.py
+++ b/toolbox/bulk_processing/new_address_processor.py
@@ -7,7 +7,8 @@ from toolbox.bulk_processing.processor_interface import Processor
 from toolbox.bulk_processing.validators import mandatory, max_length, numeric, \
     no_padding_whitespace, latitude_longitude, \
     in_set, region_matches_treatment_code, ce_u_has_expected_capacity, ce_e_has_expected_capacity, \
-    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, alphanumeric_plus_hyphen_field_values
+    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, \
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings
 from toolbox.config import Config
 from toolbox.logger import logger_initial_config
 
@@ -48,9 +49,9 @@ class NewAddressProcessor(Processor):
         'HTC_DIGITAL': [mandatory(), in_set({'0', '1', '2', '3', '4', '5'}, label='HTC_DIGITAL')],
         'TREATMENT_CODE': [mandatory(), in_set(Config.TREATMENT_CODES, label='TREATMENT_CODE')],
         'FIELDCOORDINATOR_ID': [mandatory(), max_length(10), no_padding_whitespace(), no_pipe_character(),
-                                alphanumeric_plus_hyphen_field_values()],
+                                alphanumeric_plus_hyphen_field_values_ignore_empty_strings()],
         'FIELDOFFICER_ID': [mandatory(), max_length(13), no_padding_whitespace(), no_pipe_character(),
-                            alphanumeric_plus_hyphen_field_values()],
+                            alphanumeric_plus_hyphen_field_values_ignore_empty_strings()],
         'CE_EXPECTED_CAPACITY': [numeric(), max_length(4), no_padding_whitespace(),
                                  ce_u_has_expected_capacity(), ce_e_has_expected_capacity()],
         'CE_SECURE': [mandatory(), in_set({'0', '1'}, label='CE_SECURE'),

--- a/toolbox/bulk_processing/new_address_processor.py
+++ b/toolbox/bulk_processing/new_address_processor.py
@@ -7,8 +7,7 @@ from toolbox.bulk_processing.processor_interface import Processor
 from toolbox.bulk_processing.validators import mandatory, max_length, numeric, \
     no_padding_whitespace, latitude_longitude, \
     in_set, region_matches_treatment_code, ce_u_has_expected_capacity, ce_e_has_expected_capacity, \
-    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, \
-    alphanumeric_plus_hyphen_field_values
+    alphanumeric_postcode, no_pipe_character, latitude_longitude_range, alphanumeric_plus_hyphen_field_values
 from toolbox.config import Config
 from toolbox.logger import logger_initial_config
 

--- a/toolbox/bulk_processing/non_compliance_processor.py
+++ b/toolbox/bulk_processing/non_compliance_processor.py
@@ -6,7 +6,8 @@ from structlog import wrap_logger
 
 from toolbox.bulk_processing.bulk_processor import BulkProcessor
 from toolbox.bulk_processing.processor_interface import Processor
-from toolbox.bulk_processing.validators import alphanumeric_plus_hyphen_field_values, hh_case_exists_by_id, \
+from toolbox.bulk_processing.validators import alphanumeric_plus_hyphen_field_values_ignore_empty_strings, \
+    hh_case_exists_by_id, \
     in_set, is_uuid, max_length, no_padding_whitespace, no_pipe_character
 from toolbox.config import Config
 from toolbox.logger import logger_initial_config
@@ -22,9 +23,9 @@ class NonComplianceProcessor(Processor):
         "CASE_ID": [is_uuid(), hh_case_exists_by_id()],
         "NC_STATUS": [in_set({"NCL", "NCF"}, label='non-compliance status')],
         "FIELDCOORDINATOR_ID": [max_length(10), no_padding_whitespace(), no_pipe_character(),
-                                alphanumeric_plus_hyphen_field_values()],
+                                alphanumeric_plus_hyphen_field_values_ignore_empty_strings()],
         "FIELDOFFICER_ID": [max_length(13), no_padding_whitespace(), no_pipe_character(),
-                            alphanumeric_plus_hyphen_field_values()]
+                            alphanumeric_plus_hyphen_field_values_ignore_empty_strings()]
     }
 
     def build_event_messages(self, row):

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -206,7 +206,7 @@ def alphanumeric_plus_hyphen_field_values():
 def alphanumeric_plus_hyphen_field_values_ignore_empty_strings():
     def validate(value, **_kwargs):
         stripped_field_value = value.replace("-", "")
-        if not stripped_field_value.isalnum() and stripped_field_value != "" or '':
+        if not stripped_field_value.isalnum() and stripped_field_value != "":
             raise Invalid(f'Value "{value}" contains invalid characters')
 
     return validate

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -194,10 +194,10 @@ def alphanumeric_postcode():
     return validate
 
 
-def alphanumeric_plus_hyphen_field_values():
+def alphanumeric_plus_hyphen_field_values_ignore_empty_strings():
     def validate(value, **_kwargs):
         stripped_field_value = value.replace("-", "")
-        if not stripped_field_value.isalnum():
+        if not stripped_field_value.isalnum() and stripped_field_value != "" or '':
             raise Invalid(f'Value "{value}" contains invalid characters')
 
     return validate

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -194,6 +194,15 @@ def alphanumeric_postcode():
     return validate
 
 
+def alphanumeric_plus_hyphen_field_values():
+    def validate(value, **_kwargs):
+        stripped_field_value = value.replace("-", "")
+        if not stripped_field_value.isalnum():
+            raise Invalid(f'Value "{value}" contains invalid characters')
+
+    return validate
+
+
 def alphanumeric_plus_hyphen_field_values_ignore_empty_strings():
     def validate(value, **_kwargs):
         stripped_field_value = value.replace("-", "")

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -421,7 +421,7 @@ def test_alphanumeric_plus_hyphen_field_with_empty_string_values_valid():
 
     # When
     alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator("")
-    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator('')
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator('TE-STT1-ES-01')
 
     # Then no invalid exception is raised
 

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -416,13 +416,24 @@ def test_alphanumeric_plus_hyphen_field_values_invalid():
 
 def test_alphanumeric_plus_hyphen_field_with_empty_string_values_valid():
     # Given
-    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator = \
+        validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
 
     # When
-    alphanumeric_plus_hyphen_field_validator("")
-    alphanumeric_plus_hyphen_field_validator('')
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator("")
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator('')
 
     # Then no invalid exception is raised
+
+
+def test_alphanumeric_plus_hyphen_field_with_empty_string_values_invalid():
+    # Given
+    alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator = \
+        validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        alphanumeric_plus_hyphen_field_values_ignore_empty_strings_validator(" ")
 
 
 def test_latitude_longitude_range_valid():

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -397,7 +397,7 @@ def test_alphanumeric_postcode_invalid():
 
 def test_alphanumeric_plus_hyphen_field_values_valid():
     # Given
-    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
 
     # When
     alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-01')
@@ -407,11 +407,22 @@ def test_alphanumeric_plus_hyphen_field_values_valid():
 
 def test_alphanumeric_plus_hyphen_field_values_invalid():
     # Given
-    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
 
     # When, then raises
     with pytest.raises(validators.Invalid):
         alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-!!')
+
+
+def test_alphanumeric_plus_hyphen_field_with_empty_string_values_valid():
+    # Given
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
+
+    # When
+    alphanumeric_plus_hyphen_field_validator("")
+    alphanumeric_plus_hyphen_field_validator('')
+
+    # Then no invalid exception is raised
 
 
 def test_latitude_longitude_range_valid():

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -397,7 +397,7 @@ def test_alphanumeric_postcode_invalid():
 
 def test_alphanumeric_plus_hyphen_field_values_valid():
     # Given
-    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
 
     # When
     alphanumeric_plus_hyphen_field_validator('TE-STT1-ES-01')
@@ -407,7 +407,7 @@ def test_alphanumeric_plus_hyphen_field_values_valid():
 
 def test_alphanumeric_plus_hyphen_field_values_invalid():
     # Given
-    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values_ignore_empty_strings()
+    alphanumeric_plus_hyphen_field_validator = validators.alphanumeric_plus_hyphen_field_values()
 
     # When, then raises
     with pytest.raises(validators.Invalid):


### PR DESCRIPTION
# Motivation and Context
Empty strings for FIELDCOORDINATOR_ID and FIELDOFFICER_ID were throwing up as invalid when encountering empty strings
This has only been added to non_compliance_processor.py in toolbox because the fields are not marked as mandatory in this script whereas they are elsewhere so empty strings would be caught by the mandatory() validator already

# What has changed
New validator to ignore empty strings
New test to check it works 

# How to test?
Validate a sample file with empty strings against FIELDCOORDINATOR_ID and/or FIELDOFFICER_ID

# Links
https://trello.com/c/WlOI0JYE