### PR TITLE
FIX: Check for and handle rows with incorrect number of columns

### DIFF
--- a/toolbox/bulk_processing/bulk_processor.py
+++ b/toolbox/bulk_processing/bulk_processor.py
@@ -118,13 +118,17 @@ class BulkProcessor:
         # Check we have the correct number of columns
         # If there are extra columns the values will be stored as a list in the None key
         if row.get(None):
-            errors.append(ValidationFailure(line_number, 'Multiple', 'Row contains too many columns'))
+            errors.append(ValidationFailure(line_number,
+                                            column='Multiple',
+                                            description='Row contains too many columns'))
             return errors
 
         # If we have too few columns the value for the missing end columns will be None
-        # (instead of '' for an empty but present value)
+        # (Empty but present columns values are an empty string, not None)
         if any(value is None for value in row.values()):
-            errors.append(ValidationFailure(line_number, 'Multiple', 'Row contains too few columns'))
+            errors.append(ValidationFailure(line_number,
+                                            column='Multiple',
+                                            description='Row contains too few columns'))
             return errors
 
         for column, validators in self.processor.schema.items():

--- a/toolbox/bulk_processing/bulk_processor.py
+++ b/toolbox/bulk_processing/bulk_processor.py
@@ -151,7 +151,7 @@ class BulkProcessor:
         extra_values = row.pop(None, [])
         extra_values_str = ','.join(extra_values)
 
-        rebuilt_row = ','.join({k: v for k, v in row.items() if v is not None}.values())
+        rebuilt_row = ','.join(value for value in row.values() if value is not None)
         if extra_values_str:
             rebuilt_row = rebuilt_row + f',{extra_values_str}'
 

--- a/toolbox/bulk_processing/bulk_processor.py
+++ b/toolbox/bulk_processing/bulk_processor.py
@@ -114,6 +114,19 @@ class BulkProcessor:
 
     def find_row_validation_errors(self, line_number, row):
         errors = []
+
+        # Check we have the correct number of columns
+        # If there are extra columns the values will be stored as a list in the None key
+        if row.get(None):
+            errors.append(ValidationFailure(line_number, 'Multiple', 'Row contains too many columns'))
+            return errors
+
+        # If we have too few columns the value for the missing end columns will be None
+        # (instead of '' for an empty but present value)
+        if any(value is None for value in row.values()):
+            errors.append(ValidationFailure(line_number, 'Multiple', 'Row contains too few columns'))
+            return errors
+
         for column, validators in self.processor.schema.items():
             for validator in validators:
                 try:
@@ -124,9 +137,21 @@ class BulkProcessor:
 
     def write_row_errors_to_files(self, errored_row, errors, error_file, error_detail_file):
         with open(error_file, 'a') as append_error_file:
-            append_error_file.write(','.join(errored_row.values()))
+            append_error_file.write(self.rebuild_errored_csv_row(errored_row))
             append_error_file.write('\n')
         self.write_error_details_to_file(errors, error_detail_file)
+
+    @staticmethod
+    def rebuild_errored_csv_row(row: dict):
+        # Pop and safely join any extra, unexpected columns which are stored in a list in the 'None' key
+        extra_values = row.pop(None, [])
+        extra_values_str = ','.join(extra_values)
+
+        rebuilt_row = ','.join({k: v for k, v in row.items() if v is not None}.values())
+        if extra_values_str:
+            rebuilt_row = rebuilt_row + f',{extra_values_str}'
+
+        return rebuilt_row
 
     @staticmethod
     def write_error_details_to_file(errors, error_detail_file):

--- a/toolbox/tests/bulk_processing/test_bulk_processor.py
+++ b/toolbox/tests/bulk_processing/test_bulk_processor.py
@@ -206,6 +206,101 @@ def test_run_success_failure_mix(patch_storage, patch_rabbit, patch_db_helper, t
     assert_no_left_over_files(tmp_path)
 
 
+def test_validation_row_too_long(patch_storage, patch_rabbit, patch_db_helper, tmp_path):
+    # Given
+    mock_processor = setup_mock_processor({'COL_1': []}, None)
+    bulk_processor = BulkProcessor(mock_processor)
+    bulk_processor.working_dir = tmp_path
+    mock_blob = Mock()
+    mock_blob.name = 'mock_blob_name'
+    patch_storage.Client.return_value.list_blobs.return_value = [mock_blob]
+
+    # Mock data includes an extra, unexpected column in it's row
+    patch_storage.Client.return_value.download_blob_to_file.side_effect = partial(
+        mock_download_blob,
+        mock_data=b'COL_1\n'
+                  b'col_1_value,unexpected_extra_value')
+
+    # When
+    bulk_processor.run()
+
+    # Then
+    mock_upload_to_bucket = patch_storage.Client.return_value.bucket.return_value.blob.return_value \
+        .upload_from_filename
+    mock_upload_calls = mock_upload_to_bucket.call_args_list
+    assert len(mock_upload_calls) == 2, 'Upload to bucket should be called twice'
+    assert call(str(tmp_path.joinpath('ERROR_mock_blob_name'))) in mock_upload_calls
+    assert call(str(tmp_path.joinpath('ERROR_DETAIL_mock_blob_name'))) in mock_upload_calls
+    patch_rabbit.return_value.__enter__.return_value.publish_message.assert_not_called()
+    patch_db_helper.connect_to_read_replica_pool.assert_called_once()
+
+    assert_no_left_over_files(tmp_path)
+
+
+def test_validation_row_too_short(patch_storage, patch_rabbit, patch_db_helper, tmp_path):
+    # Given
+    mock_processor = setup_mock_processor({'COL_1': [], 'COL_2': []}, None)
+    bulk_processor = BulkProcessor(mock_processor)
+    bulk_processor.working_dir = tmp_path
+    mock_blob = Mock()
+    mock_blob.name = 'mock_blob_name'
+    patch_storage.Client.return_value.list_blobs.return_value = [mock_blob]
+
+    # Mock data misses the 2nd column in it's row entirely
+    patch_storage.Client.return_value.download_blob_to_file.side_effect = partial(
+        mock_download_blob,
+        mock_data=b'COL_1,COL_2\n'
+                  b'col_1_value')
+
+    # When
+    bulk_processor.run()
+
+    # Then
+    mock_upload_to_bucket = patch_storage.Client.return_value.bucket.return_value.blob.return_value \
+        .upload_from_filename
+    mock_upload_calls = mock_upload_to_bucket.call_args_list
+    assert len(mock_upload_calls) == 2, 'Upload to bucket should be called twice'
+    assert call(str(tmp_path.joinpath('ERROR_mock_blob_name'))) in mock_upload_calls
+    assert call(str(tmp_path.joinpath('ERROR_DETAIL_mock_blob_name'))) in mock_upload_calls
+    patch_rabbit.return_value.__enter__.return_value.publish_message.assert_not_called()
+    patch_db_helper.connect_to_read_replica_pool.assert_called_once()
+
+    assert_no_left_over_files(tmp_path)
+
+
+def test_rebuild_errored_csv_row():
+    # Given
+    row_in_expected_format = {'COL_1': 'value_1', 'COL_2': 'value_2'}
+
+    # When
+    rebuilt_row = BulkProcessor.rebuild_errored_csv_row(row_in_expected_format)
+
+    # Then
+    assert rebuilt_row == 'value_1,value_2'
+
+
+def test_rebuild_errored_csv_row_too_many_columns():
+    # Given
+    row_in_expected_format = {'COL_1': 'value_1', None: ['extra_1', 'extra_2']}
+
+    # When
+    rebuilt_row = BulkProcessor.rebuild_errored_csv_row(row_in_expected_format)
+
+    # Then
+    assert rebuilt_row == 'value_1,extra_1,extra_2'
+
+
+def test_rebuild_errored_csv_row_too_few_columns():
+    # Given
+    row_in_expected_format = {'COL_1': 'value_1', 'COL_MISSING_2': None}
+
+    # When
+    rebuilt_row = BulkProcessor.rebuild_errored_csv_row(row_in_expected_format)
+
+    # Then
+    assert rebuilt_row == 'value_1'
+
+
 def setup_mock_processor(schema, test_message):
     mock_processor = Mock(spec=Processor)
     mock_processor.schema = schema

--- a/toolbox/tests/bulk_processing/test_bulk_processor.py
+++ b/toolbox/tests/bulk_processing/test_bulk_processor.py
@@ -270,17 +270,18 @@ def test_validation_row_too_short(patch_storage, patch_rabbit, patch_db_helper, 
 
 def test_rebuild_errored_csv_row():
     # Given
-    row_in_expected_format = {'COL_1': 'value_1', 'COL_2': 'value_2'}
+    row_in_expected_format = {'COL_1': 'value_1', 'COL_2': '', 'COL_3': 'value_3'}
 
     # When
     rebuilt_row = BulkProcessor.rebuild_errored_csv_row(row_in_expected_format)
 
     # Then
-    assert rebuilt_row == 'value_1,value_2'
+    assert rebuilt_row == 'value_1,,value_3'
 
 
 def test_rebuild_errored_csv_row_too_many_columns():
     # Given
+    # If a row contains too many columns, the excess will be stored in a list in the None key
     row_in_expected_format = {'COL_1': 'value_1', None: ['extra_1', 'extra_2']}
 
     # When
@@ -292,6 +293,7 @@ def test_rebuild_errored_csv_row_too_many_columns():
 
 def test_rebuild_errored_csv_row_too_few_columns():
     # Given
+    # If a row contains too few columns, the missing values on the end will be stored as None
     row_in_expected_format = {'COL_1': 'value_1', 'COL_MISSING_2': None}
 
     # When

--- a/toolbox/tests/bulk_processing/test_bulk_processor.py
+++ b/toolbox/tests/bulk_processing/test_bulk_processor.py
@@ -281,7 +281,7 @@ def test_rebuild_errored_csv_row():
 
 def test_rebuild_errored_csv_row_too_many_columns():
     # Given
-    # If a row contains too many columns, the excess will be stored in a list in the None key
+    # If a row contains too many columns then the excess will be stored in a list in the None key
     row_in_expected_format = {'COL_1': 'value_1', None: ['extra_1', 'extra_2']}
 
     # When
@@ -293,7 +293,7 @@ def test_rebuild_errored_csv_row_too_many_columns():
 
 def test_rebuild_errored_csv_row_too_few_columns():
     # Given
-    # If a row contains too few columns, the missing values on the end will be stored as None
+    # If a row contains too few columns then the missing values on the end will be stored as None
     row_in_expected_format = {'COL_1': 'value_1', 'COL_MISSING_2': None}
 
     # When


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [x] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Toolbox crashes if a row contains a bad number of columns

# What has changed
<!--- What manifest changes have been made? -->
* Check for incorrect number of columns on each row
* Handle incorrect number of columns when building error file

# How to test?
Run a file with the incorrect number of columns on a row, it should be properly reported as an error on that row

# Links
https://trello.com/c/pwy1rsjO/2060-smote-test-bug-address-update-with-error-not-properly-reported
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/380