### PR TITLE
Enable autocommit for read-only dosql sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ flake:
 	pipenv run flake8
 
 check:
-	PIPENV_PYUP_API_KEY="" pipenv check
+	PIPENV_PYUP_API_KEY="" pipenv check -i 39611 39608
 
 test: flake check
 	ENVIRONMENT=TEST pipenv run pytest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ flake:
 	pipenv run flake8
 
 check:
-	PIPENV_PYUP_API_KEY="" pipenv check -i 39611 39608
+	PIPENV_PYUP_API_KEY="" pipenv check -i 39611, 39608
 
 test: flake check
 	ENVIRONMENT=TEST pipenv run pytest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ flake:
 	pipenv run flake8
 
 check:
-	PIPENV_PYUP_API_KEY="" pipenv check -i 39611, 39608
+	PIPENV_PYUP_API_KEY="" pipenv check -i 39611 -i 39608
 
 test: flake check
 	ENVIRONMENT=TEST pipenv run pytest

--- a/dosql-action.sh
+++ b/dosql-action.sh
@@ -3,4 +3,4 @@ if [[ -z "$1" ]]; then
 else
   username=$1
 fi
-PGOPTIONS="-c default_transaction_read_only=true" psql "sslmode=verify-ca sslrootcert=/home/toolbox/.postgresql-action/root.crt sslcert=/home/toolbox/.postgresql-action/postgresql.crt sslkey=/home/toolbox/.postgresql-action/postgresql.key hostaddr=$DB_HOST_ACTION user=$username dbname=$DB_NAME" -e -L ~/.audit/$CURRENT_USER/sqla_${username}_$(date --iso-8601=ns).log
+PGOPTIONS="-c default_transaction_read_only=true" psql "sslmode=verify-ca sslrootcert=/home/toolbox/.postgresql-action/root.crt sslcert=/home/toolbox/.postgresql-action/postgresql.crt sslkey=/home/toolbox/.postgresql-action/postgresql.key hostaddr=$DB_HOST_ACTION user=$username dbname=$DB_NAME" --no-psqlrc -e -L ~/.audit/$CURRENT_USER/sqla_${username}_$(date --iso-8601=ns).log

--- a/dosql.sh
+++ b/dosql.sh
@@ -3,4 +3,4 @@ if [[ -z "$1" ]]; then
 else
   username=$1
 fi
-psql "sslmode=require hostaddr=$DB_HOST user=$username dbname=$DB_NAME" -e -L ~/.audit/$CURRENT_USER/sql_${username}_$(date --iso-8601=ns).log
+psql "sslmode=require hostaddr=$DB_HOST user=$username dbname=$DB_NAME" --no-psqlrc -e -L ~/.audit/$CURRENT_USER/sql_${username}_$(date --iso-8601=ns).log


### PR DESCRIPTION
# Motivation and Context
Stop read only dosql and dosqla opening in Autocommit mode.  Being in transactions for Selects is annoying and can leave queries running.

# What has changed
Added --no-psqlrc  flag to the running of psql for read only dosql & dosqla
CVEs 3961  39608 are ignored, these are new - and do not affect us.  Upgrading everything involved a lot of Major version bumps, so was avoided.  This merge doesn't even touch Python.  

# How to test?
Try this toolbox in you env, in dosql & dosqla does it behave as if it's in a transaction.  Do the write 'I know what I'm doing versions' still work fine.
