### PR TITLE
Check UUID before looking up

### DIFF
--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -48,6 +48,12 @@ def is_uuid():
 def case_exists_by_id():
     def validate(case_id, **kwargs):
         try:
+            # If the case ID is not a valid UUID the database lookup will fail
+            uuid.UUID(case_id, version=4)
+        except Exception:
+            raise Invalid(f'Cannot look up Case ID {case_id}, it is not a valid UUID')
+
+        try:
             case_id_exists = execute_in_connection_pool("SELECT 1 FROM casev2.cases WHERE case_id = %s",
                                                         (case_id,), conn_pool=kwargs['db_connection_pool'])
         except Exception as e:

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -69,19 +69,35 @@ def test_case_exists_by_id_succeeds(mock_execute_method):
     # When
     case_exists_validator = validators.case_exists_by_id()
 
-    case_exists_validator("valid_uuid", db_connection_pool='db_connection_pool')
+    case_exists_validator(str(uuid.uuid4()), db_connection_pool='db_connection_pool')
 
     # Then no invalid exception is raised
+    mock_execute_method.assert_called_once()
 
 
 @patch('toolbox.bulk_processing.validators.execute_in_connection_pool')
 def test_case_exists_by_id_fails(mock_execute_method):
     # Given
     mock_execute_method.return_value = []
+
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        case_exists_validator = validators.case_exists_by_id()
+        case_exists_validator(str(uuid.uuid4()), db_connection_pool='db_connection_pool')
+
+    # Then
+    mock_execute_method.assert_called_once()
+
+
+@patch('toolbox.bulk_processing.validators.execute_in_connection_pool')
+def test_case_exists_by_id_fails_gracefully_on_invalid_uuid(mock_execute_method):
     # When, then raises
     with pytest.raises(validators.Invalid):
         case_exists_validator = validators.case_exists_by_id()
         case_exists_validator("invalid_uuid", db_connection_pool='db_connection_pool')
+
+    # Then we never try to look up an invalid UUID in the database
+    mock_execute_method.assert_not_called()
 
 
 @patch('toolbox.bulk_processing.validators.execute_in_connection_pool')


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
We're seeing errors logged when processing invalid address files with blank case ID's as it is trying to look them up in the DB. We can stop this checking the case ID is a valid UUID before looking up.

# What has changed
* Add a check that case ID is a valid UUID before looking up in DB

# How to test?
Try processing an invalid address file with blank case ID's, it should log them properly as failures but not log any unexpected script errors when validating.

# Links
https://trello.com/c/cPFEax4V/2162-investigate-bulk-processor-error-handling
