### PR TITLE
Handle unexpected errors in bulk processing

### DIFF
--- a/toolbox/bulk_processing/bulk_processor.py
+++ b/toolbox/bulk_processing/bulk_processor.py
@@ -30,7 +30,8 @@ class BulkProcessor:
     def run(self):
         logger.info('Checking for files in bucket', bucket_name=self.processor.bucket_name,
                     prefix=self.processor.file_prefix)
-        with db_helper.connect_to_read_replica_pool() as self.db_connection_pool, RabbitContext() as self.rabbit:
+        with db_helper.connect_to_read_replica_pool() as self.db_connection_pool,\
+                RabbitContext(transactional=True) as self.rabbit:
             blobs_to_process = self.storage_client.list_blobs(self.processor.bucket_name,
                                                               prefix=self.processor.file_prefix)
 

--- a/toolbox/bulk_processing/bulk_processor.py
+++ b/toolbox/bulk_processing/bulk_processor.py
@@ -30,8 +30,7 @@ class BulkProcessor:
     def run(self):
         logger.info('Checking for files in bucket', bucket_name=self.processor.bucket_name,
                     prefix=self.processor.file_prefix)
-        with db_helper.connect_to_read_replica_pool() as self.db_connection_pool,\
-                RabbitContext(transactional=True) as self.rabbit:
+        with db_helper.connect_to_read_replica_pool() as self.db_connection_pool, RabbitContext() as self.rabbit:
             blobs_to_process = self.storage_client.list_blobs(self.processor.bucket_name,
                                                               prefix=self.processor.file_prefix)
 

--- a/toolbox/logger.py
+++ b/toolbox/logger.py
@@ -23,13 +23,13 @@ def logger_initial_config():
         """
         if method_name == "warn":
             # The stdlib has an alias, we always want 'warning' in full
-            method_name = "warning"
+            method_name = "WARNING"
 
         if method_name == "exception":
             # exception level is not as universal, use 'error' instead
-            method_name = "error"
+            method_name = "ERROR"
 
-        event_dict["severity"] = method_name
+        event_dict["severity"] = method_name.upper()
         return event_dict
 
     logging.basicConfig(stream=sys.stdout, level=Config.LOG_LEVEL, format="%(message)s")

--- a/toolbox/tests/bulk_processing/resources/bulk_test_file_unexpected_error.csv
+++ b/toolbox/tests/bulk_processing/resources/bulk_test_file_unexpected_error.csv
@@ -1,0 +1,4 @@
+header_1,header_2
+foo,bar
+invalid,bar
+good,values

--- a/toolbox/utilities/rabbit_context.py
+++ b/toolbox/utilities/rabbit_context.py
@@ -16,7 +16,7 @@ class RabbitContext:
         self._password = kwargs.get('password') or Config.RABBITMQ_PASSWORD
         self.queue_name = kwargs.get('queue_name')
         self.queue_declare_result = None
-        self.transactional = kwargs.get('transactional') or False
+        # self.transactional = kwargs.get('transactional') or False
 
     def __enter__(self):
         self.open_connection()
@@ -38,8 +38,8 @@ class RabbitContext:
 
         self._channel = self._connection.channel()
 
-        if self.transactional:
-            self._channel.tx_select()
+        # if self.transactional:
+        #     self._channel.tx_select()
 
         # Limit to 100 messages to avoid rabbit 'issues'
         self._channel.basic_qos(prefetch_count=100)
@@ -64,8 +64,8 @@ class RabbitContext:
             mandatory=True
         )
 
-        if self.transactional:
-            self.channel.tx_commit()
+        # if self.transactional:
+        #     self.channel.tx_commit()
 
     def get_queue_message_qty(self):
         return self.queue_declare_result.method.message_count


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
Currently if a bulk processor fails for any unexpected reason (not rows failing validation) the script crashes out, leaving the original bulk file unaltered which could be picked up again automatically in subsequent runs. I propose it should instead quarantine that file and upload the partially written results files so we manually work out how far through the processor got before failing and the file can be edited and resubmitted manually, avoiding any unwanted duplication.

# What has changed
- Catch unexpected exceptions in bulk file processing
- Quarantine the source bulk file in the event of an unexpected failure
- Upload the partially written output files to the bucket on unexpected failure

# How to test?
To test it manually in a dev env, upload a large bulk file which will take at least a few minutes to process, then while the bulk processing is working through it, manually kill it's connection. You should see it quarantine the source file and upload the results files.

# Links
https://trello.com/c/CXMtVBZn/2175-investigate-better-bulk-processor-error-handling
