### PR TITLE
allow P_RL_1RL1_1 and P_RL_1RL2B_1 to be rdr action types

### DIFF
--- a/toolbox/reminder_scheduler/constants.py
+++ b/toolbox/reminder_scheduler/constants.py
@@ -32,5 +32,7 @@ ACTION_TYPES_FOR_RESPONSE_DRIVEN_REMINDER = [
     'P_RD_RNP51',
     'P_RD_RNP52B',
     'P_QU_H1',
-    'P_QU_H2'
+    'P_QU_H2',
+    'P_RL_1RL1_1',
+    'P_RL_1RL2B_1'
 ]


### PR DESCRIPTION
# Motivation and Context
we need to allow  P_RL_1RL1_1 and P_RL_1RL2B_1 action types for response driven reminders
this PR is merging the hotfix branch back into master

# What has changed
updated the ACTION_TYPES_FOR_RESPONSE_DRIVEN_REMINDER constant to include the new action types

