### PR TITLE
Relevant Validators Now Check Case ID is a UUID Before Proceeding

### DIFF
--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -68,6 +68,12 @@ def case_exists_by_id():
 def hh_case_exists_by_id():
     def validate(case_id, **kwargs):
         try:
+            # If the HH case ID is not a valid UUID the database lookup will fail
+            uuid.UUID(case_id, version=4)
+        except Exception:
+            raise Invalid(f'Cannot look up HH Case ID {case_id}, it is not a valid UUID')
+
+        try:
             query = "SELECT 1 FROM casev2.cases WHERE case_id = %s AND case_type = 'HH'"
             case_id_exists = execute_in_connection_pool(query, (case_id,), conn_pool=kwargs['db_connection_pool'])
         except Exception as e:
@@ -238,6 +244,13 @@ def mandatory_after_update(column_name):
             return
 
         case_id = kwargs['row']['CASE_ID']
+
+        try:
+            # If the case ID is not a valid UUID the database lookup will fail
+            uuid.UUID(case_id, version=4)
+        except Exception:
+            raise Invalid(f'Cannot look up Case ID {case_id}, it is not a valid UUID')
+
         try:
             case = execute_in_connection_pool_with_column_names("SELECT * FROM casev2.cases WHERE case_id = %s",
                                                                 (case_id,), conn_pool=kwargs['db_connection_pool'])[0]

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -47,11 +47,7 @@ def is_uuid():
 
 def case_exists_by_id():
     def validate(case_id, **kwargs):
-        try:
-            # If the case ID is not a valid UUID the database lookup will fail
-            uuid.UUID(case_id, version=4)
-        except Exception:
-            raise Invalid(f'Cannot look up Case ID {case_id}, it is not a valid UUID')
+        is_case_id_a_valid_uuid(case_id)
 
         try:
             case_id_exists = execute_in_connection_pool("SELECT 1 FROM casev2.cases WHERE case_id = %s",
@@ -67,11 +63,7 @@ def case_exists_by_id():
 
 def hh_case_exists_by_id():
     def validate(case_id, **kwargs):
-        try:
-            # If the HH case ID is not a valid UUID the database lookup will fail
-            uuid.UUID(case_id, version=4)
-        except Exception:
-            raise Invalid(f'Cannot look up HH Case ID {case_id}, it is not a valid UUID')
+        is_case_id_a_valid_uuid(case_id)
 
         try:
             query = "SELECT 1 FROM casev2.cases WHERE case_id = %s AND case_type = 'HH'"
@@ -245,11 +237,7 @@ def mandatory_after_update(column_name):
 
         case_id = kwargs['row']['CASE_ID']
 
-        try:
-            # If the case ID is not a valid UUID the database lookup will fail
-            uuid.UUID(case_id, version=4)
-        except Exception:
-            raise Invalid(f'Cannot look up Case ID {case_id}, it is not a valid UUID')
+        is_case_id_a_valid_uuid(case_id)
 
         try:
             case = execute_in_connection_pool_with_column_names("SELECT * FROM casev2.cases WHERE case_id = %s",
@@ -297,3 +285,11 @@ def numeric_2_digit_or_delete():
             raise Invalid(f'Value {value} must be either a whole number between 0 and 99 or delete keyword "-----"')
 
     return validate
+
+
+def is_case_id_a_valid_uuid(case_id):
+    try:
+        # If the case ID is not a valid UUID the database lookup will fail
+        uuid.UUID(case_id, version=4)
+    except Exception:
+        raise Invalid(f'Cannot look up Case ID {case_id}, it is not a valid UUID')

--- a/toolbox/bulk_processing/validators.py
+++ b/toolbox/bulk_processing/validators.py
@@ -47,7 +47,7 @@ def is_uuid():
 
 def case_exists_by_id():
     def validate(case_id, **kwargs):
-        is_case_id_a_valid_uuid(case_id)
+        fail_validation_if_invalid_uuid(case_id)
 
         try:
             case_id_exists = execute_in_connection_pool("SELECT 1 FROM casev2.cases WHERE case_id = %s",
@@ -63,7 +63,7 @@ def case_exists_by_id():
 
 def hh_case_exists_by_id():
     def validate(case_id, **kwargs):
-        is_case_id_a_valid_uuid(case_id)
+        fail_validation_if_invalid_uuid(case_id)
 
         try:
             query = "SELECT 1 FROM casev2.cases WHERE case_id = %s AND case_type = 'HH'"
@@ -237,7 +237,7 @@ def mandatory_after_update(column_name):
 
         case_id = kwargs['row']['CASE_ID']
 
-        is_case_id_a_valid_uuid(case_id)
+        fail_validation_if_invalid_uuid(case_id)
 
         try:
             case = execute_in_connection_pool_with_column_names("SELECT * FROM casev2.cases WHERE case_id = %s",
@@ -287,7 +287,7 @@ def numeric_2_digit_or_delete():
     return validate
 
 
-def is_case_id_a_valid_uuid(case_id):
+def fail_validation_if_invalid_uuid(case_id):
     try:
         # If the case ID is not a valid UUID the database lookup will fail
         uuid.UUID(case_id, version=4)

--- a/toolbox/tests/bulk_processing/test_validators.py
+++ b/toolbox/tests/bulk_processing/test_validators.py
@@ -543,6 +543,17 @@ def test_mandatory_after_update(mock_execute_db, column_name, mock_return_value,
             mandatory_after_update_validator(value, row=row, db_connection_pool=None)
 
 
+@patch('toolbox.bulk_processing.validators.execute_in_connection_pool_with_column_names')
+def test_mandatory_after_update_fails_gracefully_on_invalid_uuid(mock_execute_method):
+    # When, then raises
+    with pytest.raises(validators.Invalid):
+        mandatory_after_update_validator = validators.mandatory_after_update("test_col")
+        mandatory_after_update_validator(value=None, row={'CASE_ID': "invalid_uuid"}, db_connection_pool=None)
+
+    # Then we never try to look up an invalid UUID in the database
+    mock_execute_method.assert_not_called()
+
+
 @pytest.mark.parametrize(['value', 'is_valid'], [
     ('-', False),
     ('--', False),


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
- We fixed this issue for invalid addresses and the case ID check in the address update file but there are other validators which attempt to look up the case in the address update processor
- These validators will still cause the timeout failure on bad format case IDs

# What has changed
- Updated validators that check the Case ID to ensure the format is valid UUID before looking it up in the DB
- Updated tests

# How to test?
- Try processing a file containing Case IDs not in a valid UUID format
- It should log them properly as failures but not log any unexpected script errors when validating

# Links
https://trello.com/c/QwhrO4zH
