### PR TITLE
Reset only resolved bad messages

### DIFF
--- a/toolbox/message_tools/bad_message_wizard.py
+++ b/toolbox/message_tools/bad_message_wizard.py
@@ -31,6 +31,7 @@ def show_home_page():
         {'description': 'Get quarantined messages', 'action': show_quarantined_messages},
         {'description': 'Quarantine all bad messages', 'action': quarantine_all_bad_messages},
         {'description': 'Reset bad message cache', 'action': reset_bad_message_cache},
+        {'description': 'Reset resolved bad messages', 'action': reset_resolved_bad_messages},
         {'description': 'Filter bad messages', 'action': filter_bad_messages}
     )
 
@@ -178,6 +179,20 @@ def reset_bad_message_cache():
         response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset')
         response.raise_for_status()
         print(colored('Successfully reset bad message cache', 'green'))
+        print('')
+    else:
+        print(colored('Aborted', 'red'))
+        print('')
+
+
+def reset_resolved_bad_messages():
+    confirmation = input(f'Confirm you want to reset '
+                         f'resolved bad messages by responding "{colored("yes", "cyan")}": ')
+    if confirmation == 'yes':
+        print(colored('Removing all resolved bad messages', 'yellow'))
+        response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset?resetOldMessages=true')
+        response.raise_for_status()
+        print(colored('Successfully reset resolved bad messages', 'green'))
         print('')
     else:
         print(colored('Aborted', 'red'))

--- a/toolbox/message_tools/bad_message_wizard.py
+++ b/toolbox/message_tools/bad_message_wizard.py
@@ -188,24 +188,24 @@ def reset_bad_message_cache():
 def reset_resolved_bad_messages():
     confirmation = input(f'Confirm you want to reset '
                          f'resolved bad messages by responding "{colored("yes", "cyan")}": ')
-    if confirmation == 'yes':
-        option = input('Resolve messages not seen in in the last? (default 300s): ')
-        if not option:
-            option = 300
-        try:
-            int(option)
-        except ValueError:
-            print(colored('Aborted', 'red'))
-            print('')
-            return
-        print(colored('Removing all resolved bad messages', 'yellow'))
-        response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset?lastSeenCutoffSeconds={option}')
-        response.raise_for_status()
-        print(colored('Successfully reset resolved bad messages', 'green'))
-        print('')
-    else:
+    if confirmation != 'yes':
         print(colored('Aborted', 'red'))
         print('')
+        return
+    option = input('Clear cached bad messages unseen for how many seconds? Press ENTER for default 300: ')
+    if not option:
+        option = 300
+    try:
+        int(option)
+    except ValueError:
+        print(colored('Aborted: Expected an integer', 'red'))
+        print('')
+        return
+    print(colored('Removing all resolved bad messages', 'yellow'))
+    response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset?lastSeenCutoffSeconds={option}')
+    response.raise_for_status()
+    print(colored('Successfully reset resolved bad messages', 'green'))
+    print('')
 
 
 def get_queue_names_and_counts(bad_messages):

--- a/toolbox/message_tools/bad_message_wizard.py
+++ b/toolbox/message_tools/bad_message_wizard.py
@@ -189,8 +189,17 @@ def reset_resolved_bad_messages():
     confirmation = input(f'Confirm you want to reset '
                          f'resolved bad messages by responding "{colored("yes", "cyan")}": ')
     if confirmation == 'yes':
+        option = input('Resolve messages not seen in in the last? (default 300s): ')
+        if not option:
+            option = 300
+        try:
+            int(option)
+        except ValueError:
+            print(colored('Aborted', 'red'))
+            print('')
+            return
         print(colored('Removing all resolved bad messages', 'yellow'))
-        response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset?resetOldMessages=true')
+        response = requests.get(f'{Config.EXCEPTIONMANAGER_URL}/reset?lastSeenCutoffSeconds={option}')
         response.raise_for_status()
         print(colored('Successfully reset resolved bad messages', 'green'))
         print('')


### PR DESCRIPTION
# Checklist
Reminder: If any change made to this repo affects the acceptance tests then the version pin in the Pipfile in [census-rm-acceptance-tests]() needs to be updated.
* [ ] Updated census-rm-acceptance-tests version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Instead of resetting all of the bad message cache, we want to have an option to be able to remove only the bad messages that have been resolved and not seen in the last 5 minutes.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added new reset option to bad message wizard

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run tests 
- Run with exception manager PR
- Create some bad messages and "resolve" them (I did this by purging the DelayedRedeliveryQueue)
- Once purged, create some more bad messages. These ones should be repeatedly seen by the exception manager.
- Wait 5 minutes and in the message wizard, use the `Reset resolved bad messages` to remove them from the cache. The only bad messages left on the bad message wizard should be the ones after the purge.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/48p2DeUH/)